### PR TITLE
create a SimpleSpanBatchSender and wire up to the example

### DIFF
--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
@@ -8,7 +8,6 @@
 package com.newrelic.telemetry;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.metrics.MetricBatchSenderBuilder;
 import java.time.Duration;
@@ -21,7 +20,7 @@ public class SimpleMetricBatchSender {
 
   public static MetricBatchSenderBuilder builder(String apiKey, Duration callTimeout) {
     OkHttpPoster okHttpPoster = new OkHttpPoster(callTimeout);
-    Gson gson = new GsonBuilder().create();
+    Gson gson = new Gson();
     return MetricBatchSender.builder()
         .apiKey(apiKey)
         .metricToJson(new MetricToGson(gson))

--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
@@ -16,7 +16,7 @@ import java.time.Duration;
 public class SimpleMetricBatchSender {
 
   public static MetricBatchSenderBuilder builder(String apiKey) {
-    return builder(apiKey, Duration.ZERO);
+    return builder(apiKey, Duration.ofSeconds(2));
   }
 
   public static MetricBatchSenderBuilder builder(String apiKey, Duration callTimeout) {

--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleMetricBatchSender.java
@@ -14,8 +14,16 @@ import java.time.Duration;
 
 public class SimpleMetricBatchSender {
 
+  public static MetricBatchSender build(String apiKey) {
+    return builder(apiKey).build();
+  }
+
   public static MetricBatchSenderBuilder builder(String apiKey) {
     return builder(apiKey, Duration.ofSeconds(2));
+  }
+
+  public static MetricBatchSender build(String apiKey, Duration callTimeout) {
+    return builder(apiKey, callTimeout).build();
   }
 
   public static MetricBatchSenderBuilder builder(String apiKey, Duration callTimeout) {

--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
@@ -1,7 +1,6 @@
 package com.newrelic.telemetry;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.spans.SpanBatchSender;
 import com.newrelic.telemetry.spans.SpanBatchSenderBuilder;
@@ -23,10 +22,9 @@ public class SimpleSpanBatchSender {
 
   public static SpanBatchSenderBuilder builder(String apiKey, Duration callTimeout) {
     HttpPoster http = new OkHttpPoster(callTimeout);
-    Gson gson = new GsonBuilder().create();
     return SpanBatchSender.builder()
         .apiKey(apiKey)
         .httpPoster(http)
-        .attributesJson(new AttributesGson(gson));
+        .attributesJson(new AttributesGson(new Gson()));
   }
 }

--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
@@ -1,0 +1,32 @@
+package com.newrelic.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.spans.SpanBatchSender;
+import com.newrelic.telemetry.spans.SpanBatchSenderBuilder;
+import java.time.Duration;
+
+public class SimpleSpanBatchSender {
+
+  public static SpanBatchSender build(String apiKey) {
+    return build(apiKey, Duration.ZERO);
+  }
+
+  public static SpanBatchSenderBuilder builder(String apiKey) {
+    return builder(apiKey);
+  }
+
+  public static SpanBatchSender build(String apiKey, Duration callTimeout) {
+    return builder(apiKey, callTimeout).build();
+  }
+
+  public static SpanBatchSenderBuilder builder(String apiKey, Duration callTimeout) {
+    HttpPoster http = new OkHttpPoster(callTimeout);
+    Gson gson = new GsonBuilder().create();
+    return SpanBatchSender.builder()
+        .apiKey(apiKey)
+        .httpPoster(http)
+        .attributesJson(new AttributesGson(gson));
+  }
+}

--- a/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
+++ b/telemetry_components/src/main/java/com/newrelic/telemetry/SimpleSpanBatchSender.java
@@ -10,7 +10,7 @@ import java.time.Duration;
 public class SimpleSpanBatchSender {
 
   public static SpanBatchSender build(String apiKey) {
-    return build(apiKey, Duration.ZERO);
+    return build(apiKey, Duration.ofSeconds(2));
   }
 
   public static SpanBatchSenderBuilder builder(String apiKey) {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSenderBuilder.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSenderBuilder.java
@@ -35,22 +35,26 @@ public class MetricBatchSenderBuilder {
     Utils.verifyNonNull(metricToJson, "an MetricToJson implementation is required.");
     Utils.verifyNonNull(attributesJson, "an AttributesJson implementation is required.");
 
-    if (metricsUrl == null) {
-      try {
-        metricsUrl = constructMetricsUrlWithHost(URI.create("https://metric-api.newrelic.com/"));
-      } catch (MalformedURLException e) {
-        throw new UncheckedIOException("Bad hardcoded URL", e);
-      }
-    }
+    URL url = getOrDefaultMetricsUrl();
 
     MetricBatchMarshaller marshaller =
         new MetricBatchMarshaller(
             new MetricBatchJsonCommonBlockWriter(attributesJson),
             new MetricBatchJsonTelemetryBlockWriter(metricToJson));
-    BatchDataSender sender =
-        new BatchDataSender(httpPoster, apiKey, metricsUrl, auditLoggingEnabled);
+    BatchDataSender sender = new BatchDataSender(httpPoster, apiKey, url, auditLoggingEnabled);
 
     return new MetricBatchSender(marshaller, sender);
+  }
+
+  private URL getOrDefaultMetricsUrl() {
+    if (metricsUrl == null) {
+      try {
+        return constructMetricsUrlWithHost(URI.create("https://metric-api.newrelic.com/"));
+      } catch (MalformedURLException e) {
+        throw new UncheckedIOException("Bad hardcoded URL", e);
+      }
+    }
+    return metricsUrl;
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSenderBuilder.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSenderBuilder.java
@@ -37,14 +37,9 @@ public class SpanBatchSenderBuilder {
   public SpanBatchSender build() {
     Utils.verifyNonNull(apiKey, "API key cannot be null");
     Utils.verifyNonNull(httpPoster, "an HttpPoster implementation is required.");
+    Utils.verifyNonNull(attributesJson, "an AttributesJson implementation is required.");
 
-    if (traceUrl == null) {
-      try {
-        traceUrl = constructSpansUrlWithHost(URI.create("https://trace-api.newrelic.com/"));
-      } catch (MalformedURLException e) {
-        throw new UncheckedIOException("Bad hardcoded URL", e);
-      }
-    }
+    URL traceUrl = getOrDefaultTraceUrl();
 
     SpanBatchMarshaller marshaller =
         new SpanBatchMarshaller(
@@ -52,6 +47,17 @@ public class SpanBatchSenderBuilder {
             new SpanJsonTelemetryBlockWriter(attributesJson));
     BatchDataSender sender = new BatchDataSender(httpPoster, apiKey, traceUrl, auditLoggingEnabled);
     return new SpanBatchSender(marshaller, sender);
+  }
+
+  private URL getOrDefaultTraceUrl() {
+    if (traceUrl == null) {
+      try {
+        return constructSpansUrlWithHost(URI.create("https://trace-api.newrelic.com/"));
+      } catch (MalformedURLException e) {
+        throw new UncheckedIOException("Bad hardcoded URL", e);
+      }
+    }
+    return traceUrl;
   }
 
   /**

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderBuilderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderBuilderTest.java
@@ -1,0 +1,53 @@
+package com.newrelic.telemetry.spans;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.json.AttributesJson;
+import org.junit.jupiter.api.Test;
+
+class SpanBatchSenderBuilderTest {
+
+  @Test
+  void testBuild() {
+    SpanBatchSender result =
+        new SpanBatchSenderBuilder()
+            .apiKey("123")
+            .attributesJson(mock(AttributesJson.class))
+            .httpPoster(mock(HttpPoster.class))
+            .build();
+    assertNotNull(result);
+  }
+
+  @Test
+  void testMissingApiKey() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new SpanBatchSenderBuilder()
+                .attributesJson(mock(AttributesJson.class))
+                .httpPoster(mock(HttpPoster.class))
+                .build());
+  }
+
+  @Test
+  void testMissingAttributesJson() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new SpanBatchSenderBuilder().apiKey("123").httpPoster(mock(HttpPoster.class)).build());
+  }
+
+  @Test
+  void testMissingHttpPoster() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new SpanBatchSenderBuilder()
+                .apiKey("123")
+                .attributesJson(mock(AttributesJson.class))
+                .build());
+  }
+}

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/SpanExample.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/SpanExample.java
@@ -7,10 +7,8 @@
 
 package com.newrelic.telemetry.examples;
 
-import com.google.gson.Gson;
 import com.newrelic.telemetry.Attributes;
-import com.newrelic.telemetry.AttributesGson;
-import com.newrelic.telemetry.OkHttpPoster;
+import com.newrelic.telemetry.SimpleSpanBatchSender;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
@@ -44,10 +42,7 @@ public class SpanExample {
     String insightsInsertKey = args[0];
 
     SpanBatchSender sender =
-        SpanBatchSender.builder()
-            .apiKey(insightsInsertKey)
-            .httpPoster(new OkHttpPoster(Duration.ofSeconds(5)))
-            .attributesJson(new AttributesGson(new Gson()))
+        SimpleSpanBatchSender.builder(insightsInsertKey, Duration.ofSeconds(5))
             .enableAuditLogging()
             .build();
 


### PR DESCRIPTION
This addresses #58.

A few other notable changes:
* adds builder verification for the attributes json instance being supplied (wasn't checked before)
* adds test coverage around the builder verifications

I'm also looking for feedback on the fact that I exposed 4 methods on the `SimpleSpanBatchSender` -- 2 that return the builder in case the user wants additional customization (like in the example) and 2 that return the 'Sender directly.
