### PR TITLE
repackage gson classes back into a google package

### DIFF
--- a/telemetry_core/src/main/java/com/google/gson/stream/JsonScope.java
+++ b/telemetry_core/src/main/java/com/google/gson/stream/JsonScope.java
@@ -16,7 +16,7 @@
  *
  * Note: this code is originally from the gson project at https://github.com/google/gson
  */
-package com.newrelic.telemetry.json;
+package com.google.gson.stream;
 
 final class JsonScope {
 

--- a/telemetry_core/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/telemetry_core/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -17,15 +17,15 @@
  * Note: this code is originally from the gson project at https://github.com/google/gson
  */
 
-package com.newrelic.telemetry.json;
+package com.google.gson.stream;
 
-import static com.newrelic.telemetry.json.JsonScope.DANGLING_NAME;
-import static com.newrelic.telemetry.json.JsonScope.EMPTY_ARRAY;
-import static com.newrelic.telemetry.json.JsonScope.EMPTY_DOCUMENT;
-import static com.newrelic.telemetry.json.JsonScope.EMPTY_OBJECT;
-import static com.newrelic.telemetry.json.JsonScope.NONEMPTY_ARRAY;
-import static com.newrelic.telemetry.json.JsonScope.NONEMPTY_DOCUMENT;
-import static com.newrelic.telemetry.json.JsonScope.NONEMPTY_OBJECT;
+import static com.google.gson.stream.JsonScope.DANGLING_NAME;
+import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;
+import static com.google.gson.stream.JsonScope.EMPTY_DOCUMENT;
+import static com.google.gson.stream.JsonScope.EMPTY_OBJECT;
+import static com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
+import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
+import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
 import java.io.Closeable;
 import java.io.Flushable;

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/json/AttributesJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/json/AttributesJson.java
@@ -6,6 +6,7 @@
  */
 package com.newrelic.telemetry.json;
 
+import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
@@ -7,8 +7,8 @@
 
 package com.newrelic.telemetry.metrics.json;
 
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
-import com.newrelic.telemetry.json.JsonWriter;
 import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Summary;

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanBatchMarshaller.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanBatchMarshaller.java
@@ -1,6 +1,6 @@
 package com.newrelic.telemetry.spans.json;
 
-import com.newrelic.telemetry.json.JsonWriter;
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;
 import java.io.StringWriter;

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
@@ -7,8 +7,8 @@
 
 package com.newrelic.telemetry.spans.json;
 
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
-import com.newrelic.telemetry.json.JsonWriter;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;
 import lombok.AllArgsConstructor;

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriter.java
@@ -7,8 +7,8 @@
 
 package com.newrelic.telemetry.spans.json;
 
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
-import com.newrelic.telemetry.json.JsonWriter;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriterTest.java
@@ -11,9 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.json.AttributesJson;
-import com.newrelic.telemetry.json.JsonWriter;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;
 import java.io.StringWriter;

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriterTest.java
@@ -9,9 +9,9 @@ package com.newrelic.telemetry.spans.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.json.AttributesJson;
-import com.newrelic.telemetry.json.JsonWriter;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;


### PR DESCRIPTION
This resolves #72  and should help us down the road when we want to rework the license headers.