### PR TITLE
Allow Summary metrics to have null min or max values

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricBatchJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricBatchJsonTelemetryBlockWriter.java
@@ -42,8 +42,7 @@ public class MetricBatchJsonTelemetryBlockWriter {
         metric,
         count -> isFinite((count.getValue())),
         gauge -> isFinite((gauge.getValue())),
-        summary ->
-            isFinite(summary.getMax()) && isFinite(summary.getMin()) && isFinite(summary.getSum()));
+        summary -> isFinite(summary.getSum()));
   }
 
   private String toJsonString(Metric metric) {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
@@ -29,8 +29,10 @@ public class MetricToJson {
       jsonWriter.beginObject();
       jsonWriter.name("count").value(summary.getCount());
       jsonWriter.name("sum").value(summary.getSum());
-      jsonWriter.name("min").value(summary.getMin());
-      jsonWriter.name("max").value(summary.getMax());
+      jsonWriter.name("min");
+      writeDouble(jsonWriter, summary.getMin());
+      jsonWriter.name("max");
+      writeDouble(jsonWriter, summary.getMax());
       jsonWriter.endObject();
 
       jsonWriter.name("timestamp").value(summary.getStartTimeMs());
@@ -85,6 +87,14 @@ public class MetricToJson {
       return out.toString();
     } catch (IOException e) {
       throw new RuntimeException("Failed to generate count json");
+    }
+  }
+
+  private void writeDouble(final JsonWriter jsonWriter, final double value) throws IOException {
+    if (Double.isFinite(value)) {
+      jsonWriter.value(value);
+    } else {
+      jsonWriter.nullValue();
     }
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricsBatchMarshallerTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricsBatchMarshallerTest.java
@@ -112,16 +112,32 @@ class MetricsBatchMarshallerTest {
                 new Gauge("gaugeNegInf", Double.NEGATIVE_INFINITY, 555, new Attributes()),
                 new Gauge("gaugePosInf", Double.POSITIVE_INFINITY, 555, new Attributes()),
                 new Summary(
-                    "summarySumBad", 100, Double.NaN, 1000d, 1000d, 555, 666, new Attributes()),
-                new Summary(
-                    "summaryMinBad", 100, 1000d, Double.NaN, 1000d, 555, 666, new Attributes()),
-                new Summary(
-                    "summaryMaxBad", 100, 1000d, 1000d, Double.NaN, 555, 666, new Attributes())),
+                    "summarySumBad", 100, Double.NaN, 1000d, 1000d, 555, 666, new Attributes())),
             commonAttributes);
     String json = metricBatchMarshaller.toJson(metricBatch);
 
     String expected = "[{\"metrics\":[]}]";
     JSONAssert.assertEquals(expected, json, false);
+  }
+
+  @Test
+  @DisplayName("Metric formatting handles null min and max")
+  void testNullMinMaxMetricValues() throws Exception {
+
+    Attributes commonAttributes = new Attributes();
+
+    MetricBatch metricBatch =
+        new MetricBatch(
+            Arrays.asList(
+                new Summary(
+                    "summaryMinNull", 100, 1000d, Double.NaN, 1000d, 555, 666, new Attributes()),
+                new Summary(
+                    "summaryMaxNull", 100, 1000d, 1000d, Double.NaN, 555, 666, new Attributes())),
+            commonAttributes);
+    String json = metricBatchMarshaller.toJson(metricBatch);
+
+    assertTrue(json.contains("\"min\":null"));
+    assertTrue(json.contains("\"max\":null"));
   }
 
   @Test


### PR DESCRIPTION
Not all metric sources provide both min and max values for all metrics which we might
want to map to Summaries.  This allows either of these fields to be null, which the
NewRelic data backend will interpret as a double NaN and treat appropriately.