### PR TITLE
tweak the log level for IOExceptions and add recommendation information to existing logging.

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -191,7 +191,7 @@ public class BatchDataSender {
     List<String> retryAfter = findHeader(responseHeaders, "retry-after");
     int retryAfterSeconds = getRetryAfterValue(response, responseBody, retryAfter);
     logger.warn(
-        "Response from New Relic ingest API. Retry with wait recommended.b: code: {}, body: {}, retry-after: {}",
+        "Response from New Relic ingest API. Retry with wait recommended : code: {}, body: {}, retry-after: {}",
         response.getCode(),
         responseBody,
         retryAfterSeconds);


### PR DESCRIPTION
I think this could help address issues with users not understand what's going on wrt. retries and network timeouts. 