### PR TITLE
chore: Raname the com.google.gson package to vendored.com.google.gson to avoid conflicts with existing loaded gson versions

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/json/EventToJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/json/EventToJson.java
@@ -5,12 +5,12 @@
 
 package com.newrelic.telemetry.events.json;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.events.Event;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.function.Function;
+import vendored.com.google.gson.stream.JsonWriter;
 
 public class EventToJson implements Function<Event, String> {
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/json/AttributesJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/json/AttributesJson.java
@@ -4,12 +4,12 @@
  */
 package com.newrelic.telemetry.json;
 
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import vendored.com.google.gson.stream.JsonWriter;
 
 public class AttributesJson {
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricToJson.java
@@ -4,13 +4,13 @@
  */
 package com.newrelic.telemetry.metrics.json;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Summary;
 import java.io.IOException;
 import java.io.StringWriter;
+import vendored.com.google.gson.stream.JsonWriter;
 
 /** This class turns Metrics into JSON via an embedded JsonWriter from the gson project. */
 public class MetricToJson {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanBatchMarshaller.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanBatchMarshaller.java
@@ -4,12 +4,12 @@
  */
 package com.newrelic.telemetry.spans.json;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import vendored.com.google.gson.stream.JsonWriter;
 
 public class SpanBatchMarshaller {
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
@@ -4,10 +4,10 @@
  */
 package com.newrelic.telemetry.spans.json;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.spans.SpanBatch;
 import java.io.IOException;
+import vendored.com.google.gson.stream.JsonWriter;
 
 public class SpanJsonCommonBlockWriter {
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriter.java
@@ -4,7 +4,6 @@
  */
 package com.newrelic.telemetry.spans.json;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
@@ -12,6 +11,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import vendored.com.google.gson.stream.JsonWriter;
 
 public final class SpanJsonTelemetryBlockWriter {
 

--- a/telemetry_core/src/main/java/vendored/com/google/gson/stream/JsonScope.java
+++ b/telemetry_core/src/main/java/vendored/com/google/gson/stream/JsonScope.java
@@ -16,7 +16,7 @@
  *
  * Note: this code is originally from the gson project at https://github.com/google/gson
  */
-package com.google.gson.stream;
+package vendored.com.google.gson.stream;
 
 final class JsonScope {
 

--- a/telemetry_core/src/main/java/vendored/com/google/gson/stream/JsonWriter.java
+++ b/telemetry_core/src/main/java/vendored/com/google/gson/stream/JsonWriter.java
@@ -17,15 +17,15 @@
  * Note: this code is originally from the gson project at https://github.com/google/gson
  */
 
-package com.google.gson.stream;
+package vendored.com.google.gson.stream;
 
-import static com.google.gson.stream.JsonScope.DANGLING_NAME;
-import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;
-import static com.google.gson.stream.JsonScope.EMPTY_DOCUMENT;
-import static com.google.gson.stream.JsonScope.EMPTY_OBJECT;
-import static com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
-import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
-import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
+import static vendored.com.google.gson.stream.JsonScope.DANGLING_NAME;
+import static vendored.com.google.gson.stream.JsonScope.EMPTY_ARRAY;
+import static vendored.com.google.gson.stream.JsonScope.EMPTY_DOCUMENT;
+import static vendored.com.google.gson.stream.JsonScope.EMPTY_OBJECT;
+import static vendored.com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
+import static vendored.com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
+import static vendored.com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
 import java.io.Closeable;
 import java.io.Flushable;

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriterTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.spans.SpanBatch;
@@ -17,6 +16,7 @@ import java.io.StringWriter;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import vendored.com.google.gson.stream.JsonWriter;
 
 class SpanJsonCommonBlockWriterTest {
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/json/SpanJsonTelemetryBlockWriterTest.java
@@ -6,7 +6,6 @@ package com.newrelic.telemetry.spans.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.spans.Span;
@@ -17,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import vendored.com.google.gson.stream.JsonWriter;
 
 class SpanJsonTelemetryBlockWriterTest {
 


### PR DESCRIPTION
### Summary

Following the discussion opened here: https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/72#issuecomment-620769410 I moved the copied classes (`JsonScope`, `JsonWriter`) from the [Gson package](https://github.com/google/gson) library to a different package than the original one `com.google.gson` to `vendored.com.google.gson`.

This will solve the issue when the `newrelic-telemetry-sdk-java` is imported in a project that is using an old version of `Gson` for example `2.3.1` which doesn't have the `JsonWriter.jsonValue` method and a runtime exception is thrown.

I have chosen the `vendored` prefix for the existing packages, I'm not proud of it, but it will work, another solution could be to configure a shadow plugin for grade to do this automatically for certain packages.