### PR TITLE
Change the integration tests to do strict JSON verification.

### DIFF
--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -104,7 +104,7 @@ class SpanApiIntegrationTest {
                     json(
                         new SpanPayload[] {expectedPayload},
                         MediaType.JSON_UTF_8,
-                        MatchType.ONLY_MATCHING_FIELDS))
+                        MatchType.STRICT))
                 .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* myTestApp")
                 .withHeader("Content-Type", "application/json; charset=utf-8")
                 .withHeader("Content-Length", ".*"))
@@ -142,6 +142,14 @@ class SpanApiIntegrationTest {
     public SpanPayload(ImmutableMap<String, Object> of, List<Map<String, Object>> singletonList) {
       common = of;
       spans = singletonList;
+    }
+
+    public Map<String, Object> getCommon() {
+      return common;
+    }
+
+    public List<Map<String, Object>> getSpans() {
+      return spans;
     }
   }
 }


### PR DESCRIPTION
The lack of the strict option meant we weren't validating the payload at all, due to changes when lombok was removed.