### PR TITLE
Add logging API to the SDK

### DIFF
--- a/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.model.JsonBody.json;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.MediaType;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import com.newrelic.telemetry.logs.LogBatchSender;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.matchers.MatchType;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class LogApiIntegrationTest {
+
+  private static final int SERVICE_PORT = 1080 + new Random().nextInt(900);
+  private static String containerIpAddress;
+  private static MockServerClient mockServerClient;
+  private static final GenericContainer<?> container =
+      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
+          .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
+          .withExposedPorts(SERVICE_PORT);
+  private LogBatchSender logBatchSender;
+
+  @BeforeAll
+  static void beforeClass() {
+    container.setPortBindings(singletonList(SERVICE_PORT + ":1080"));
+    container.setWaitStrategy(new WaitAllStrategy());
+    container.setStartupCheckStrategy(
+        new MinimumDurationRunningStartupCheckStrategy(Duration.of(10, SECONDS)));
+    container.start();
+    containerIpAddress = container.getContainerIpAddress();
+    mockServerClient = new MockServerClient(containerIpAddress, SERVICE_PORT);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockServerClient.reset();
+    SenderConfiguration config =
+        LogBatchSenderFactory.fromHttpImplementation(OkHttpPoster::new)
+            .configureWith("fakeKey")
+            .httpPoster(new OkHttpPoster(Duration.ofMillis(1500)))
+            .endpoint("http", containerIpAddress, SERVICE_PORT)
+            .auditLoggingEnabled(true)
+            .secondaryUserAgent("myTestApp")
+            .build();
+    logBatchSender = LogBatchSender.create(config);
+  }
+
+  @Test
+  @DisplayName("Low Level SDK can send a log batch and returns a successful response")
+  void testSuccessfulSpanSend() throws Exception {
+    LogPayload expectedPayload =
+        new LogPayload(
+            ImmutableMap.of("attributes", singletonMap("key1", "val1")),
+            singletonList(
+                ImmutableMap.<String, Object>builder()
+                    .put("timestamp", 55555)
+                    .put("message", "log message goes here")
+                    .put(
+                        "attributes",
+                        ImmutableMap.of("service.name", "Log Test Service", "log.level", "DEBUG"))
+                    .build()));
+
+    mockServerClient
+        .when(
+            new HttpRequest()
+                .withMethod("POST")
+                .withPath("/log/v1")
+                .withBody(
+                    json(
+                        new LogPayload[] {expectedPayload}, MediaType.JSON_UTF_8, MatchType.STRICT))
+                .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* myTestApp")
+                .withHeader("Content-Type", "application/json; charset=utf-8")
+                .withHeader("Content-Length", ".*"))
+        .respond(new HttpResponse().withStatusCode(202));
+
+    List<Log> logs = new ArrayList<>();
+    logs.add(
+        Log.builder()
+            .message("log message goes here")
+            .level("DEBUG")
+            .timestamp(55555)
+            .serviceName("Log Test Service")
+            .build());
+    Response response = logBatchSender.sendBatch(new LogBatch(logs, getCommonAttributes()));
+
+    assertEquals(202, response.getStatusCode());
+    assertEquals("Accepted", response.getStatusMessage());
+  }
+
+  private static Attributes getCommonAttributes() {
+    return new Attributes().put("key1", "val1");
+  }
+
+  /*
+  [{"common":{"attributes":{"key1":"val1","exampleName":"LogExample"}},
+    "logs":[{"timestamp":55555,"attributes":{"log.level":"DEBUG"},"message":"log message goes here"}]}]
+   */
+
+  private static class LogPayload {
+    private final Map<String, Object> common;
+    private final List<Map<String, Object>> logs;
+
+    public LogPayload(
+        ImmutableMap<String, Object> commonAttributes, List<Map<String, Object>> data) {
+      common = commonAttributes;
+      logs = data;
+    }
+
+    public Map<String, Object> getCommon() {
+      return common;
+    }
+
+    public List<Map<String, Object>> getLogs() {
+      return logs;
+    }
+  }
+}

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -11,6 +11,8 @@ import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
 import com.newrelic.telemetry.exceptions.RetryWithRequestedWaitException;
 import com.newrelic.telemetry.exceptions.RetryWithSplitException;
 import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.logs.LogBatch;
+import com.newrelic.telemetry.logs.LogBatchSender;
 import com.newrelic.telemetry.metrics.MetricBatch;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.spans.SpanBatch;
@@ -38,6 +40,8 @@ public class TelemetryClient {
   private final EventBatchSender eventBatchSender;
   private final MetricBatchSender metricBatchSender;
   private final SpanBatchSender spanBatchSender;
+  private final LogBatchSender logBatchSender;
+
   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
   /**
@@ -46,15 +50,18 @@ public class TelemetryClient {
    *
    * @param metricBatchSender The sender for dimensional metrics.
    * @param spanBatchSender The sender for distributed tracing spans.
-   * @param eventBatchSender The sender for custom events
+   * @param eventBatchSender The sender for custom events.
+   * @param logBatchSender The sender for log entries.
    */
   public TelemetryClient(
       MetricBatchSender metricBatchSender,
       SpanBatchSender spanBatchSender,
-      EventBatchSender eventBatchSender) {
+      EventBatchSender eventBatchSender,
+      LogBatchSender logBatchSender) {
     this.metricBatchSender = metricBatchSender;
     this.spanBatchSender = spanBatchSender;
     this.eventBatchSender = eventBatchSender;
+    this.logBatchSender = logBatchSender;
   }
 
   /**
@@ -68,7 +75,7 @@ public class TelemetryClient {
    */
   @Deprecated
   public TelemetryClient(MetricBatchSender metricBatchSender, SpanBatchSender spanBatchSender) {
-    this(metricBatchSender, spanBatchSender, null);
+    this(metricBatchSender, spanBatchSender, null, null);
   }
 
   private interface BatchSender {
@@ -76,8 +83,9 @@ public class TelemetryClient {
   }
 
   /**
-   * Send a batch of metrics, with standard retry logic. This happens on a background thread,
-   * asynchronously, so currently there will be no feedback to the caller outside of the logs.
+   * Send a batch of {@link com.newrelic.telemetry.metrics.Metric} instances, with standard retry
+   * logic. This happens on a background thread, asynchronously, so currently there will be no
+   * feedback to the caller outside of the logs.
    */
   public void sendBatch(MetricBatch batch) {
     scheduleBatchSend(
@@ -85,20 +93,31 @@ public class TelemetryClient {
   }
 
   /**
-   * Send a batch of spans, with standard retry logic. This happens on a background thread,
-   * asynchronously, so currently there will be no feedback to the caller outside of the logs.
+   * Send a batch of {@link com.newrelic.telemetry.spans.Span} instances, with standard retry logic.
+   * This happens on a background thread, asynchronously, so currently there will be no feedback to
+   * the caller outside of the logs.
    */
   public void sendBatch(SpanBatch batch) {
     scheduleBatchSend((b) -> spanBatchSender.sendBatch((SpanBatch) b), batch, 0, TimeUnit.SECONDS);
   }
 
   /**
-   * Send a batch of events, with standard retry logic. This happens on a background thread,
-   * asynchronously, so currently there will be no feedback to the caller outside of the logs.
+   * Send a batch of {@link com.newrelic.telemetry.events.Event} instances, with standard retry
+   * logic. This happens on a background thread, asynchronously, so currently there will be no
+   * feedback to the caller outside of the logs.
    */
   public void sendBatch(EventBatch batch) {
     scheduleBatchSend(
         (b) -> eventBatchSender.sendBatch((EventBatch) b), batch, 0, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Send a batch of {@link com.newrelic.telemetry.logs.Log} entries, with standard retry logic.
+   * This happens on a background thread, asynchronously, so currently there will be no feedback to
+   * the caller outside of the logs.
+   */
+  public void sendBatch(LogBatch batch) {
+    scheduleBatchSend((b) -> logBatchSender.sendBatch((LogBatch) b), batch, 0, TimeUnit.SECONDS);
   }
 
   private void scheduleBatchSend(
@@ -201,6 +220,12 @@ public class TelemetryClient {
                 .configureWith(insertApiKey)
                 .build());
 
-    return new TelemetryClient(metricBatchSender, spanBatchSender, eventBatchSender);
+    LogBatchSender logBatchSender =
+        LogBatchSender.create(
+            LogBatchSenderFactory.fromHttpImplementation(httpPosterCreator::get)
+                .configureWith(insertApiKey)
+                .build());
+    return new TelemetryClient(
+        metricBatchSender, spanBatchSender, eventBatchSender, logBatchSender);
   }
 }

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -45,8 +45,8 @@ public class TelemetryClient {
   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
   /**
-   * Create a new TelemetryClient instance, with three senders. Note that if you don't intend to
-   * send one of the telemetry types, you can pass in a null value for that sender.
+   * Create a new TelemetryClient instance, with four senders. Note that if you don't intend to send
+   * one of the telemetry types, you can pass in a null value for that sender.
    *
    * @param metricBatchSender The sender for dimensional metrics.
    * @param spanBatchSender The sender for distributed tracing spans.
@@ -204,25 +204,25 @@ public class TelemetryClient {
       Supplier<HttpPoster> httpPosterCreator, String insertApiKey) {
     MetricBatchSender metricBatchSender =
         MetricBatchSender.create(
-            MetricBatchSenderFactory.fromHttpImplementation(httpPosterCreator::get)
+            MetricBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
                 .configureWith(insertApiKey)
                 .build());
 
     SpanBatchSender spanBatchSender =
         SpanBatchSender.create(
-            SpanBatchSenderFactory.fromHttpImplementation(httpPosterCreator::get)
+            SpanBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
                 .configureWith(insertApiKey)
                 .build());
 
     EventBatchSender eventBatchSender =
         EventBatchSender.create(
-            EventBatchSenderFactory.fromHttpImplementation(httpPosterCreator::get)
+            EventBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
                 .configureWith(insertApiKey)
                 .build());
 
     LogBatchSender logBatchSender =
         LogBatchSender.create(
-            LogBatchSenderFactory.fromHttpImplementation(httpPosterCreator::get)
+            LogBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
                 .configureWith(insertApiKey)
                 .build());
     return new TelemetryClient(

--- a/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.newrelic.telemetry;
@@ -53,7 +53,7 @@ class TelemetryClientTest {
     CountDownLatch sendLatch = new CountDownLatch(1);
     when(batchSender.sendBatch(metricBatch)).thenAnswer(countDown(sendLatch));
 
-    TelemetryClient testClass = new TelemetryClient(batchSender, null, null);
+    TelemetryClient testClass = new TelemetryClient(batchSender, null, null, logBatchSender);
 
     testClass.sendBatch(metricBatch);
     boolean result = sendLatch.await(3, TimeUnit.SECONDS);
@@ -66,7 +66,7 @@ class TelemetryClientTest {
     CountDownLatch sendLatch = new CountDownLatch(1);
     when(batchSender.sendBatch(spanBatch)).thenAnswer(countDown(sendLatch));
 
-    TelemetryClient testClass = new TelemetryClient(null, batchSender, null);
+    TelemetryClient testClass = new TelemetryClient(null, batchSender, null, logBatchSender);
 
     testClass.sendBatch(spanBatch);
     boolean result = sendLatch.await(3, TimeUnit.SECONDS);
@@ -79,7 +79,7 @@ class TelemetryClientTest {
     CountDownLatch sendLatch = new CountDownLatch(1);
     when(batchSender.sendBatch(eventBatch)).thenAnswer(countDown(sendLatch));
 
-    TelemetryClient testClass = new TelemetryClient(null, null, batchSender);
+    TelemetryClient testClass = new TelemetryClient(null, null, batchSender, logBatchSender);
 
     testClass.sendBatch(eventBatch);
     boolean result = sendLatch.await(3, TimeUnit.SECONDS);
@@ -101,7 +101,7 @@ class TelemetryClientTest {
         .thenAnswer(requestRetry)
         .thenAnswer(countDown(sendLatch));
 
-    TelemetryClient testClass = new TelemetryClient(batchSender, null, null);
+    TelemetryClient testClass = new TelemetryClient(batchSender, null, null, logBatchSender);
 
     testClass.sendBatch(metricBatch);
     boolean result = sendLatch.await(10, TimeUnit.SECONDS);
@@ -119,7 +119,7 @@ class TelemetryClientTest {
             })
         .thenAnswer(countDown(sendLatch));
 
-    TelemetryClient testClass = new TelemetryClient(batchSender, null, null);
+    TelemetryClient testClass = new TelemetryClient(batchSender, null, null, logBatchSender);
 
     testClass.sendBatch(metricBatch);
     boolean result = sendLatch.await(3, TimeUnit.SECONDS);
@@ -153,7 +153,7 @@ class TelemetryClientTest {
               return null;
             });
 
-    TelemetryClient testClass = new TelemetryClient(batchSender, null, null);
+    TelemetryClient testClass = new TelemetryClient(batchSender, null, null, logBatchSender);
 
     testClass.sendBatch(batch);
     boolean result = sendLatch.await(3, TimeUnit.SECONDS);

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry;
+
+import com.newrelic.telemetry.SenderConfiguration.SenderConfigurationBuilder;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.logs.LogBatchSender;
+import java.util.function.Supplier;
+
+/**
+ * A factory interface for creating a LogBatchSender.
+ *
+ * <p>Concrete implementations use different HTTP providers.
+ */
+public interface LogBatchSenderFactory {
+
+  /**
+   * Create a new LogBatchSender with your New Relic Insights Insert API key, and otherwise default
+   * settings. (2 second timeout, audit logging off, with the default endpoint URL)
+   *
+   * @see <a
+   *     href="https://docs.newrelic.com/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key">New
+   *     Relic API Keys</a>
+   */
+  default LogBatchSender createBatchSender(String apiKey) {
+    SenderConfigurationBuilder configuration =
+        LogBatchSender.configurationBuilder().apiKey(apiKey).httpPoster(getPoster());
+    return LogBatchSender.create(configuration.build());
+  }
+
+  /**
+   * Create a new {@link SenderConfigurationBuilder} with your New Relic Insights Insert API key.
+   *
+   * @see <a
+   *     href="https://docs.newrelic.com/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key">New
+   *     Relic API Keys</a>
+   */
+  default SenderConfigurationBuilder configureWith(String apiKey) {
+    return LogBatchSender.configurationBuilder().apiKey(apiKey).httpPoster(getPoster());
+  }
+
+  HttpPoster getPoster();
+
+  /**
+   * Create an {@link LogBatchSenderFactory} with an HTTP implementation.
+   *
+   * @param creator A {@link Supplier} that returns an {@link HttpPoster} implementation.
+   * @return A Factory configured for use.
+   */
+  static LogBatchSenderFactory fromHttpImplementation(Supplier<HttpPoster> creator) {
+    return creator::get;
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.telemetry.logs;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.Telemetry;
+import com.newrelic.telemetry.util.Utils;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class Log implements Telemetry {
+  private final long timestamp; // in epoch ms
+  private final String message;
+  private final Attributes attributes;
+  private final String serviceName; // service.name <- goes in attributes
+  private final String logType;
+  private final String level;
+
+  private Log(LogBuilder builder) {
+    this.timestamp = builder.timestamp;
+    this.message = builder.message;
+    this.attributes = builder.attributes;
+    this.serviceName = builder.serviceName;
+    this.logType = builder.logType;
+    this.level = builder.level;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public String getLogType() {
+    return logType;
+  }
+
+  public String getLevel() {
+    return level;
+  }
+
+  public static LogBuilder builder() {
+    return new LogBuilder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Log)) {
+      return false;
+    }
+
+    Log log = (Log) o;
+
+    if (timestamp != log.timestamp) {
+      return false;
+    }
+    if (message != null ? !message.equals(log.message) : log.message != null) {
+      return false;
+    }
+    if (attributes != null ? !attributes.equals(log.attributes) : log.attributes != null) {
+      return false;
+    }
+    if (serviceName != null ? !serviceName.equals(log.serviceName) : log.serviceName != null) {
+      return false;
+    }
+    if (logType != null ? !logType.equals(log.logType) : log.logType != null) {
+      return false;
+    }
+    return level != null ? level.equals(log.level) : log.level == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (timestamp ^ (timestamp >>> 32));
+    result = 31 * result + (message != null ? message.hashCode() : 0);
+    result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+    result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
+    result = 31 * result + (logType != null ? logType.hashCode() : 0);
+    result = 31 * result + (level != null ? level.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Log{"
+        + "timestamp="
+        + timestamp
+        + ", message='"
+        + message
+        + '\''
+        + ", attributes="
+        + attributes
+        + ", serviceName='"
+        + serviceName
+        + '\''
+        + ", logType='"
+        + logType
+        + '\''
+        + ", level='"
+        + level
+        + '\''
+        + '}';
+  }
+
+  /**
+   * A class for holding the variables associated with a Span object and creating a new Span object
+   * with those variables
+   */
+  public static class LogBuilder {
+    private long timestamp = System.currentTimeMillis();
+    private String message;
+    private Attributes attributes = new Attributes();
+    private String serviceName; // service.name <- goes in attributes
+    private String logType; // logtype <- goes in attributes
+    private String level;
+
+    public LogBuilder timestamp(long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public LogBuilder level(String logLevel) {
+      this.level = logLevel;
+      return this;
+    }
+
+    public LogBuilder message(String message) {
+      this.message = message;
+      return this;
+    }
+
+    public LogBuilder attributes(Attributes attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    public LogBuilder serviceName(String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
+
+    public Log build() {
+      Utils.verifyNonBlank(message, "A message is required for a log entry");
+      return new Log(this);
+    }
+
+    @Override
+    public String toString() {
+      return "LogBuilder{"
+          + "timestamp="
+          + timestamp
+          + ", message='"
+          + message
+          + '\''
+          + ", attributes="
+          + attributes
+          + ", serviceName='"
+          + serviceName
+          + '\''
+          + '}';
+    }
+
+    public LogBuilder logType(String type) {
+      this.logType = type;
+      return this;
+    }
+
+    /** Will fill in the message with the stack trace from the Throwable. */
+    public LogBuilder stackTrace(Throwable e) {
+      Utils.verifyNonNull(e);
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      e.printStackTrace(new PrintStream(bytes));
+      this.message = bytes.toString();
+      this.logType = "stackTrace";
+      return this;
+    }
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -119,7 +119,7 @@ public class Log implements Telemetry {
   }
 
   /**
-   * A class for holding the variables associated with a Span object and creating a new Span object
+   * A class for holding the variables associated with a Log object and creating a new Log object
    * with those variables
    */
   public static class LogBuilder {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -11,6 +11,7 @@ import com.newrelic.telemetry.util.Utils;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+/** A Log instance represents a single entry in a log. */
 public class Log implements Telemetry {
   private final long timestamp; // in epoch ms
   private final String message;
@@ -28,30 +29,37 @@ public class Log implements Telemetry {
     this.level = builder.level;
   }
 
+  /** The point in time (ms since UNIX epoch) that the log entry was created. */
   public long getTimestamp() {
     return timestamp;
   }
 
+  /** The log line itself. */
   public String getMessage() {
     return message;
   }
 
+  /** Additional attributes associated with the log entry. */
   public Attributes getAttributes() {
     return attributes;
   }
 
+  /** The name of the service which produced this log entry. */
   public String getServiceName() {
     return serviceName;
   }
 
+  /** The type of log entry. This can be helpful for querying your log entries in New Relic. */
   public String getLogType() {
     return logType;
   }
 
+  /** The log level (eg. INFO, DEBUG, etc) for the log entry. */
   public String getLevel() {
     return level;
   }
 
+  /** Create a builder for building a new log entry. */
   public static LogBuilder builder() {
     return new LogBuilder();
   }
@@ -120,7 +128,7 @@ public class Log implements Telemetry {
 
   /**
    * A class for holding the variables associated with a Log object and creating a new Log object
-   * with those variables
+   * with those variables.
    */
   public static class LogBuilder {
     private long timestamp = System.currentTimeMillis();
@@ -130,34 +138,59 @@ public class Log implements Telemetry {
     private String logType; // logtype <- goes in attributes
     private String level;
 
+    /** The point in time (ms since UNIX epoch) that the log entry was created. */
     public LogBuilder timestamp(long timestamp) {
       this.timestamp = timestamp;
       return this;
     }
 
-    public LogBuilder level(String logLevel) {
-      this.level = logLevel;
-      return this;
-    }
-
+    /** The log line itself. */
     public LogBuilder message(String message) {
       this.message = message;
       return this;
     }
 
+    /** Additional attributes associated with the log entry. */
     public LogBuilder attributes(Attributes attributes) {
       this.attributes = attributes;
       return this;
     }
 
+    /** The name of the service which produced this log entry. */
     public LogBuilder serviceName(String serviceName) {
       this.serviceName = serviceName;
       return this;
     }
 
+    /** The log level (eg. INFO, DEBUG, etc) for the log entry. */
+    public LogBuilder level(String logLevel) {
+      this.level = logLevel;
+      return this;
+    }
+
+    /** The type of log entry. This can be helpful for querying your log entries in New Relic. */
+    public LogBuilder logType(String type) {
+      this.logType = type;
+      return this;
+    }
+
+    /** Create the new {@link Log} entry. */
     public Log build() {
       Utils.verifyNonBlank(message, "A message is required for a log entry");
       return new Log(this);
+    }
+
+    /**
+     * Will fill in the {@link #message(String)} with the stack trace from the Throwable. This will
+     * also set the {@link #logType(String)} to be "stackTrace".
+     */
+    public LogBuilder stackTrace(Throwable e) {
+      Utils.verifyNonNull(e);
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      e.printStackTrace(new PrintStream(bytes));
+      this.message = bytes.toString();
+      this.logType = "stackTrace";
+      return this;
     }
 
     @Override
@@ -174,21 +207,6 @@ public class Log implements Telemetry {
           + serviceName
           + '\''
           + '}';
-    }
-
-    public LogBuilder logType(String type) {
-      this.logType = type;
-      return this;
-    }
-
-    /** Will fill in the message with the stack trace from the Throwable. */
-    public LogBuilder stackTrace(Throwable e) {
-      Utils.verifyNonNull(e);
-      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-      e.printStackTrace(new PrintStream(bytes));
-      this.message = bytes.toString();
-      this.logType = "stackTrace";
-      return this;
     }
   }
 }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatch.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatch.java
@@ -9,6 +9,7 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.TelemetryBatch;
 import java.util.Collection;
 
+/** Represents a set of {@link Log} instances, to be sent up to the New Relic Logging API. */
 public class LogBatch extends TelemetryBatch<Log> {
   public LogBatch(Collection<Log> telemetry, Attributes commonAttributes) {
     super(telemetry, commonAttributes);

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatch.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatch.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.telemetry.logs;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.TelemetryBatch;
+import java.util.Collection;
+
+public class LogBatch extends TelemetryBatch<Log> {
+  public LogBatch(Collection<Log> telemetry, Attributes commonAttributes) {
+    super(telemetry, commonAttributes);
+  }
+
+  @Override
+  public TelemetryBatch<Log> createSubBatch(Collection<Log> telemetry) {
+    return new LogBatch(telemetry, getCommonAttributes());
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs;
+
+import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.SenderConfiguration;
+import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.json.AttributesJson;
+import com.newrelic.telemetry.logs.json.LogBatchMarshaller;
+import com.newrelic.telemetry.logs.json.LogJsonCommonBlockWriter;
+import com.newrelic.telemetry.logs.json.LogJsonTelemetryBlockWriter;
+import com.newrelic.telemetry.transport.BatchDataSender;
+import com.newrelic.telemetry.util.Utils;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Manages the sending of {@link LogBatch} instances to the New Relic Logs API. */
+public class LogBatchSender {
+
+  private static final String LOGS_PATH = "/log/v1";
+  private static final String DEFAULT_URL = "https://log-api.newrelic.com/";
+
+  private static final Logger logger = LoggerFactory.getLogger(LogBatchSender.class);
+
+  private final LogBatchMarshaller marshaller;
+  private final BatchDataSender sender;
+
+  /**
+   * Creates a log batch sender that knows how to marshall log batches and send them
+   *
+   * @param marshaller Defines how to marshall log batches
+   * @param sender Sends log batches
+   */
+  LogBatchSender(LogBatchMarshaller marshaller, BatchDataSender sender) {
+    this.marshaller = marshaller;
+    this.sender = sender;
+  }
+
+  /**
+   * Send a batch of logs to New Relic.
+   *
+   * @param batch The batch to send. This batch will be drained of accumulated logs as a part of
+   *     this process.
+   * @return The response from the ingest API.
+   * @throws ResponseException In cases where the batch is unable to be successfully sent, one of
+   *     the subclasses of {@link ResponseException} will be thrown. See the documentation on that
+   *     hierarchy for details on the recommended ways to respond to those exceptions.
+   */
+  public Response sendBatch(LogBatch batch) throws ResponseException {
+    if (batch == null || batch.size() == 0) {
+      logger.debug("Skipped sending a null or empty log batch");
+      return new Response(202, "Ignored", "Empty batch");
+    }
+    logger.debug(
+        "Sending a log batch (number of logs: {}) to the New Relic log ingest endpoint)",
+        batch.size());
+    String json = marshaller.toJson(batch);
+    return sender.send(json);
+  }
+
+  /**
+   * Build the final {@link LogBatchSender}.
+   *
+   * @return the fully configured LogBatchSender object
+   */
+  public static LogBatchSender create(SenderConfiguration configuration) {
+    Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
+    Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
+
+    URL url = configuration.getEndpointUrl();
+
+    LogBatchMarshaller marshaller =
+        new LogBatchMarshaller(
+            new LogJsonCommonBlockWriter(new AttributesJson()),
+            new LogJsonTelemetryBlockWriter(new AttributesJson()));
+    BatchDataSender sender =
+        new BatchDataSender(
+            configuration.getHttpPoster(),
+            configuration.getApiKey(),
+            url,
+            configuration.isAuditLoggingEnabled(),
+            configuration.getSecondaryUserAgent());
+
+    return new LogBatchSender(marshaller, sender);
+  }
+
+  public static SenderConfiguration.SenderConfigurationBuilder configurationBuilder() {
+    return SenderConfiguration.builder(DEFAULT_URL, LOGS_PATH);
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogBatchMarshaller.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogBatchMarshaller.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs.json;
+
+import com.google.gson.stream.JsonWriter;
+import com.newrelic.telemetry.logs.LogBatch;
+import java.io.IOException;
+import java.io.StringWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogBatchMarshaller {
+
+  private static final Logger logger = LoggerFactory.getLogger(LogBatchMarshaller.class);
+  private final LogJsonCommonBlockWriter commonBlockWriter;
+  private final LogJsonTelemetryBlockWriter telemetryBlockWriter;
+
+  public LogBatchMarshaller(
+      LogJsonCommonBlockWriter commonBlockWriter,
+      LogJsonTelemetryBlockWriter telemetryBlockWriter) {
+    this.commonBlockWriter = commonBlockWriter;
+    this.telemetryBlockWriter = telemetryBlockWriter;
+  }
+
+  public String toJson(LogBatch batch) {
+    logger.debug("Generating json for log batch.");
+
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    try {
+      jsonWriter.beginArray().beginObject();
+      commonBlockWriter.appendCommonJson(batch, jsonWriter);
+      telemetryBlockWriter.appendTelemetryJson(batch, jsonWriter);
+      jsonWriter.endObject().endArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to marshall json for a log batch");
+    }
+
+    return out.toString();
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs.json;
+
+import com.google.gson.stream.JsonWriter;
+import com.newrelic.telemetry.json.AttributesJson;
+import com.newrelic.telemetry.logs.LogBatch;
+import java.io.IOException;
+
+public class LogJsonCommonBlockWriter {
+
+  private final AttributesJson attributesJson;
+
+  public LogJsonCommonBlockWriter(AttributesJson attributesJson) {
+    this.attributesJson = attributesJson;
+  }
+
+  public void appendCommonJson(LogBatch batch, JsonWriter jsonWriter) {
+    if (!batch.hasCommonAttributes()) {
+      return;
+    }
+    try {
+      jsonWriter.name("common");
+      jsonWriter.beginObject();
+      jsonWriter.name("attributes");
+      jsonWriter.jsonValue(attributesJson.toJson(batch.getCommonAttributes().asMap()));
+      jsonWriter.endObject();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create span common block json", e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "LogJsonCommonBlockWriter{" + "attributesJson=" + attributesJson + '}';
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriter.java
@@ -28,7 +28,7 @@ public class LogJsonCommonBlockWriter {
       jsonWriter.jsonValue(attributesJson.toJson(batch.getCommonAttributes().asMap()));
       jsonWriter.endObject();
     } catch (IOException e) {
-      throw new RuntimeException("Failed to create span common block json", e);
+      throw new RuntimeException("Failed to create log common block json", e);
     }
   }
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs.json;
+
+import com.google.gson.stream.JsonWriter;
+import com.newrelic.telemetry.json.AttributesJson;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class LogJsonTelemetryBlockWriter {
+
+  private final AttributesJson attributesJson;
+
+  public LogJsonTelemetryBlockWriter(AttributesJson attributesJson) {
+    this.attributesJson = attributesJson;
+  }
+
+  public void appendTelemetryJson(LogBatch batch, JsonWriter jsonWriter) {
+    try {
+      jsonWriter.name("logs");
+      jsonWriter.beginArray();
+      Collection<Log> telemetry = batch.getTelemetry();
+      for (Log log : telemetry) {
+        jsonWriter.beginObject();
+        jsonWriter.name("timestamp").value(log.getTimestamp());
+        jsonWriter.name("attributes").jsonValue(attributesJson.toJson(enhanceAttributes(log)));
+        jsonWriter.name("message").value(log.getMessage());
+        jsonWriter.endObject();
+      }
+      jsonWriter.endArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate span telemetry json", e);
+    }
+  }
+
+  private Map<String, Object> enhanceAttributes(Log log) {
+    Map<String, Object> result = new HashMap<>(log.getAttributes().asMap());
+    result.putIfAbsent("service.name", log.getServiceName());
+    if (log.getLevel() != null) {
+      result.put("level", log.getLevel());
+    }
+    if (log.getLogType() != null) {
+      result.put("logtype", log.getLogType());
+    }
+    return result;
+  }
+
+  public AttributesJson getAttributesJson() {
+    return attributesJson;
+  }
+
+  @Override
+  public String toString() {
+    return "LogJsonTelemetryBlockWriter{" + "attributesJson=" + attributesJson + '}';
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
@@ -8,7 +8,9 @@ import com.google.gson.stream.JsonWriter;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.logs.Log;
 import com.newrelic.telemetry.logs.LogBatch;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,16 +45,17 @@ public final class LogJsonTelemetryBlockWriter {
     Map<String, Object> result = new HashMap<>(log.getAttributes().asMap());
     result.putIfAbsent("service.name", log.getServiceName());
     if (log.getLevel() != null) {
-      result.put("level", log.getLevel());
+      result.put("log.level", log.getLevel());
     }
-    if (log.getLogType() != null) {
-      result.put("logtype", log.getLogType());
+    Throwable throwable = log.getThrowable();
+    if (throwable != null) {
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      throwable.printStackTrace(new PrintStream(bytes));
+      result.put("error.message", throwable.getMessage());
+      result.put("error.class", throwable.getClass().getName());
+      result.put("error.stack", bytes.toString());
     }
     return result;
-  }
-
-  public AttributesJson getAttributesJson() {
-    return attributesJson;
   }
 
   @Override

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriter.java
@@ -32,7 +32,9 @@ public final class LogJsonTelemetryBlockWriter {
         jsonWriter.beginObject();
         jsonWriter.name("timestamp").value(log.getTimestamp());
         jsonWriter.name("attributes").jsonValue(attributesJson.toJson(enhanceAttributes(log)));
-        jsonWriter.name("message").value(log.getMessage());
+        if (log.getMessage() != null) {
+          jsonWriter.name("message").value(log.getMessage());
+        }
         jsonWriter.endObject();
       }
       jsonWriter.endArray();

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/json/SpanJsonCommonBlockWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.newrelic.telemetry.spans.json;
@@ -11,7 +11,7 @@ import java.io.IOException;
 
 public class SpanJsonCommonBlockWriter {
 
-  private AttributesJson attributesJson;
+  private final AttributesJson attributesJson;
 
   public SpanJsonCommonBlockWriter(AttributesJson attributesJson) {
     this.attributesJson = attributesJson;

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.logs.json.LogBatchMarshaller;
+import com.newrelic.telemetry.transport.BatchDataSender;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class LogBatchSenderTest {
+
+  @Test
+  void testSimpleSend() throws Exception {
+    Log log = Log.builder().build();
+    LogBatch batch = new LogBatch(Collections.singletonList(log), new Attributes().put("j", "k"));
+    String json = "{a great document}";
+    Response response = new Response(123, "OK", "yup");
+
+    LogBatchMarshaller marshaller = mock(LogBatchMarshaller.class);
+    BatchDataSender sender = mock(BatchDataSender.class);
+
+    when(marshaller.toJson(batch)).thenReturn(json);
+    when(sender.send(json)).thenReturn(response);
+
+    LogBatchSender testClass = new LogBatchSender(marshaller, sender);
+
+    Response result = testClass.sendBatch(batch);
+    assertEquals(response, result);
+  }
+
+  @Test
+  void testEmptyBatch() throws Exception {
+    LogBatchSender testClass = new LogBatchSender(null, null);
+    LogBatch batch = new LogBatch(Collections.emptyList(), new Attributes());
+    Response response = testClass.sendBatch(batch);
+    assertEquals(202, response.getStatusCode());
+  }
+}

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/json/LogJsonCommonBlockWriterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.stream.JsonWriter;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.json.AttributesJson;
+import com.newrelic.telemetry.logs.LogBatch;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LogJsonCommonBlockWriterTest {
+
+  private AttributesJson attributesJson;
+
+  @BeforeEach
+  void setup() {
+    attributesJson = mock(AttributesJson.class);
+  }
+
+  @Test
+  void testAppendJsonWithCommonAttributes() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    String expected = "{\"common\":{\"attributes\":{\"You\":\"Wish\"}}}";
+    LogBatch batch = new LogBatch(Collections.emptyList(), new Attributes().put("You", "Wish"));
+
+    when(attributesJson.toJson(batch.getCommonAttributes().asMap()))
+        .thenReturn("{\"You\":\"Wish\"}");
+    LogJsonCommonBlockWriter testClass = new LogJsonCommonBlockWriter(attributesJson);
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendCommonJson(batch, jsonWriter);
+    jsonWriter.endObject();
+
+    assertEquals(expected, out.toString());
+  }
+
+  @Test
+  void testAppendJsonNoTraceIdNoCommonAttributes() {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    String expected = "";
+    LogBatch batch = new LogBatch(Collections.emptyList(), new Attributes());
+
+    LogJsonCommonBlockWriter testClass = new LogJsonCommonBlockWriter(attributesJson);
+    testClass.appendCommonJson(batch, jsonWriter);
+
+    assertEquals(expected, out.toString());
+  }
+}

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/json/LogJsonTelemetryBlockWriterTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.logs.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.json.AttributesJson;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class LogJsonTelemetryBlockWriterTest {
+
+  @Test
+  void testHappyPath() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    Log log1 =
+        Log.builder()
+            .timestamp(99999)
+            .serviceName("Hot.Service")
+            .level("DEBUG")
+            .message("log message 1")
+            .attributes(new Attributes().put("a", "b"))
+            .build();
+
+    Log log2 =
+        Log.builder()
+            .timestamp(88888)
+            .serviceName("Cold.\"Light\".Service")
+            .level("INFO")
+            .message("log message 2")
+            .attributes(new Attributes().put("c", "d"))
+            .build();
+
+    Collection<Log> telemetry = Arrays.asList(log1, log2);
+    Attributes commonAttributes = new Attributes().put("come", "on");
+    LogBatch batch = new LogBatch(telemetry, commonAttributes);
+    String log1Expected =
+        "{\"timestamp\":99999,"
+            + "\"attributes\":{\"a\":\"b\",\"service.name\":\"Hot.Service\",\"log.level\":\"DEBUG\"},\"message\":\"log message 1\"}";
+    String log2Expected =
+        "{\"timestamp\":88888,"
+            + "\"attributes\":{\"c\":\"d\",\"service.name\":\"Cold.\\\"Light\\\".Service\",\"log.level\":\"INFO\"},\"message\":\"log message 2\"}";
+    String expected = "{\"logs\":[" + log1Expected + "," + log2Expected + "]}";
+
+    AttributesJson attributesJson = new AttributesJson();
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(attributesJson);
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(batch, jsonWriter);
+    jsonWriter.endObject();
+    String result = out.toString();
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testMinimum() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    Log log = Log.builder().timestamp(12345).build();
+    LogBatch logBatch = new LogBatch(Collections.singleton(log), new Attributes());
+
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(new AttributesJson());
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(logBatch, jsonWriter);
+    jsonWriter.endObject();
+
+    String result = out.toString();
+
+    String expected = "{\"logs\":[{\"timestamp\":12345,\"attributes\":{}}]}";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testThrowable() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    Log log = Log.builder().timestamp(5555).throwable(new Exception("exception message")).build();
+    LogBatch logBatch = new LogBatch(Collections.singleton(log), new Attributes());
+
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(new AttributesJson());
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(logBatch, jsonWriter);
+    jsonWriter.endObject();
+
+    String result = out.toString();
+
+    Map<String, Object> resultData = new Gson().fromJson(result, Map.class);
+    List<Map<String, Object>> logs = (List<Map<String, Object>>) resultData.get("logs");
+    Map<String, Object> logEntry = logs.get(0);
+    Map<String, Object> attributes = (Map<String, Object>) logEntry.get("attributes");
+    assertNotNull(attributes);
+    assertEquals("exception message", attributes.get("error.message"));
+    assertEquals("java.lang.Exception", attributes.get("error.class"));
+    assertNotNull(attributes.get("error.stack"));
+  }
+
+  /** This case should be guarded against at a higher level in the calling code. */
+  @Test
+  void testNoLogs() throws Exception {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    LogBatch logBatch = new LogBatch(Collections.emptyList(), new Attributes());
+
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(new AttributesJson());
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(logBatch, jsonWriter);
+    jsonWriter.endObject();
+
+    String result = out.toString();
+
+    String expected = "{\"logs\":[]}";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testAttributesSetButNotProperties() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    Attributes attrs =
+        new Attributes()
+            .put("service.name", "ipanema")
+            .put("parent.id", "0xff")
+            .put("duration.ms", 101)
+            .put("name", "lucy");
+    Log log = Log.builder().timestamp(12345).attributes(attrs).build();
+    LogBatch logBatch = new LogBatch(Collections.singleton(log), new Attributes());
+
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(new AttributesJson());
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(logBatch, jsonWriter);
+    jsonWriter.endObject();
+
+    String result = out.toString();
+
+    String expected =
+        "{\"logs\":[{\"timestamp\":12345,\"attributes\":{"
+            + "\"duration.ms\":101,"
+            + "\"service.name\":\"ipanema\","
+            + "\"name\":\"lucy\","
+            + "\"parent.id\":\"0xff\""
+            + "}}]}";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testNullAttributesDontOverrideAndAreOmitted() throws IOException {
+    StringWriter out = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(out);
+
+    Attributes attrs =
+        new Attributes()
+            .put("service.name", (String) null)
+            .put("message", (String) null)
+            .put("log.level", (String) null)
+            .put("error.message", (String) null)
+            .put("error.class", (String) null)
+            .put("error.stack", (String) null);
+    Log log =
+        Log.builder()
+            .timestamp(12345)
+            .attributes(attrs)
+            .serviceName("my service")
+            .message("message")
+            .level("DEBUG")
+            .throwable(new Exception("exception message"))
+            .build();
+    LogBatch logBatch = new LogBatch(Collections.singleton(log), new Attributes());
+
+    LogJsonTelemetryBlockWriter testClass = new LogJsonTelemetryBlockWriter(new AttributesJson());
+
+    jsonWriter
+        .beginObject(); // Because we are testing through a real writer, we have to give it object
+    // context in order to do fragment work
+    testClass.appendTelemetryJson(logBatch, jsonWriter);
+    jsonWriter.endObject();
+
+    String result = out.toString();
+
+    Map<String, Object> resultData = new Gson().fromJson(result, Map.class);
+    List<Map<String, Object>> logs = (List<Map<String, Object>>) resultData.get("logs");
+    Map<String, Object> logEntry = logs.get(0);
+    assertEquals("message", logEntry.get("message"));
+    Map<String, Object> attributes = (Map<String, Object>) logEntry.get("attributes");
+    assertNotNull(attributes);
+    assertEquals("DEBUG", attributes.get("log.level"));
+    assertEquals("my service", attributes.get("service.name"));
+    assertEquals("exception message", attributes.get("error.message"));
+    assertEquals("java.lang.Exception", attributes.get("error.class"));
+    assertNotNull(attributes.get("error.stack"));
+  }
+}

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
@@ -6,12 +6,14 @@ package com.newrelic.telemetry.examples;
 
 import com.newrelic.telemetry.EventBatchSenderFactory;
 import com.newrelic.telemetry.Java11HttpPoster;
+import com.newrelic.telemetry.LogBatchSenderFactory;
 import com.newrelic.telemetry.MetricBatchSenderFactory;
 import com.newrelic.telemetry.OkHttpPoster;
 import com.newrelic.telemetry.SimpleMetricBatchSender;
 import com.newrelic.telemetry.SpanBatchSenderFactory;
 import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.events.EventBatchSender;
+import com.newrelic.telemetry.logs.LogBatchSender;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.spans.SpanBatchSender;
 import java.net.MalformedURLException;
@@ -32,7 +34,7 @@ public class ConfigurationExamples {
             .apiKey(insightsInsertKey)
             .httpPoster(new OkHttpPoster(Duration.ofSeconds(2)))
             .build();
-    new TelemetryClient(sender, null, null);
+    new TelemetryClient(sender, null, null, null);
 
     // new configuration methods:
     /////////////////////////////////////////////////////////////////////
@@ -91,7 +93,14 @@ public class ConfigurationExamples {
                 .endpointWithPath(new URL("http://special-events.com/my-endpoint-rocks/v1/api"))
                 .build());
 
+    // Configure your log sender:
+    LogBatchSender logBatchSender =
+        LogBatchSender.create(
+            LogBatchSenderFactory.fromHttpImplementation(Java11HttpPoster::new)
+                .configureWith(insightsInsertKey)
+                .build());
+
     // Build your TelemetryClient with the 3 senders.
-    new TelemetryClient(metricBatchSender, spanBatchSender, eventBatchSender);
+    new TelemetryClient(metricBatchSender, spanBatchSender, eventBatchSender, logBatchSender);
   }
 }

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/LogExample.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/LogExample.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.telemetry.examples;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.OkHttpPoster;
+import com.newrelic.telemetry.SenderConfiguration;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import com.newrelic.telemetry.logs.LogBatchSender;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an example of sending a batch of Logs to New Relic.
+ *
+ * <p>A LogBatchSender is created with the Insights insert key and the reference http implementation
+ * from OkHttp. An example batch of 4 logs (apples, oranges, beer, wine) is created and then sent
+ * via sender.sendBatch().
+ *
+ * <p>To run this example, pass the insights api key as a commandline argument.
+ */
+public class LogExample {
+  private static final Logger logger = LoggerFactory.getLogger(LogExample.class);
+
+  private static final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+  private static final List<String> items = Arrays.asList("apples", "oranges", "beer", "wine");
+
+  public static void main(String[] args) throws Exception {
+    logger.info("Starting the LogExample");
+    String insightsInsertKey = args[0];
+
+    SenderConfiguration configuration =
+        LogBatchSender.configurationBuilder()
+            .apiKey(insightsInsertKey)
+            .auditLoggingEnabled(true)
+            .httpPoster(new OkHttpPoster())
+            .build();
+    LogBatchSender sender = LogBatchSender.create(configuration);
+
+    List<Log> logs = new ArrayList<>();
+    logs.add(Log.builder().level("INFO").message("Start of process").build());
+    for (String item : items) {
+      String logId = UUID.randomUUID().toString();
+      Attributes attributes = new Attributes().put("id", logId).put("food", item);
+      logs.add(
+          Log.builder()
+              .attributes(attributes)
+              .message("Processing " + item)
+              .level("DEBUG")
+              .build());
+      if (new Random().nextBoolean()) {
+        logs.add(
+            Log.builder()
+                .attributes(attributes)
+                .level("ERROR")
+                .stackTrace(makeException(item))
+                .build());
+      }
+      logs.add(
+          Log.builder()
+              .attributes(attributes)
+              .message("Done processing " + item)
+              .level("DEBUG")
+              .build());
+    }
+    logs.add(Log.builder().level("INFO").message("End of process").build());
+
+    sender.sendBatch(new LogBatch(logs, getCommonAttributes()));
+  }
+
+  private static Exception makeException(String item) {
+    return aLevelDeeper(item);
+  }
+
+  private static Exception aLevelDeeper(String item) {
+    return new Exception("Exceptional things with the " + item + "!");
+  }
+
+  /** These attributes are shared across all logs submitted in the batch. */
+  private static Attributes getCommonAttributes() {
+    return new Attributes()
+        .put("exampleName", "LogExample")
+        .put("service.name", "Telemetry SDK Log Example");
+  }
+}

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/LogExample.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/LogExample.java
@@ -62,8 +62,9 @@ public class LogExample {
         logs.add(
             Log.builder()
                 .attributes(attributes)
+                .message("Failed to process " + item)
                 .level("ERROR")
-                .stackTrace(makeException(item))
+                .throwable(makeException(item))
                 .build());
       }
       logs.add(


### PR DESCRIPTION
This addition to the SDK will be useful for non-typical logging usages, such as reporting OpenTelemetry Span Events as log entries, in context. It's not intended as an API to be used to implement high-throughput logging systems. That use-case should be reserved for log forwarder implementations.