### PR TITLE
Gradle updates and fixes to remove Gson dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
 
 }
 
-listOf(":telemetry-core", ":telemetry", ":telemetry-http-okhttp", ":telemetry-http-java11").forEach {
+listOf(":telemetry", ":telemetry-http-okhttp", ":telemetry-http-java11").forEach {
     project(it) {
         apply(plugin = "java-library")
         apply(plugin = "maven-publish")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,14 +3,11 @@ import com.newrelic.telemetry.gradle.configuredPom
 
 plugins {
     java
+    id("java-library")
+    id("maven-publish")
+    id("signing")
+    id("com.github.sherter.google-java-format") version "0.8"
 }
-
-apply(plugin = "java")
-apply(plugin = "java-library")
-apply(plugin = "maven-publish")
-apply(plugin = "signing")
-
-apply(plugin = "com.github.sherter.google-java-format")
 
 allprojects {
     group = "com.newrelic.telemetry"
@@ -50,8 +47,12 @@ listOf(":telemetry", ":telemetry-http-okhttp", ":telemetry-http-java11").forEach
 
             val jar: Jar by taskScope
             jar.apply {
-                manifest.attributes["Implementation-Version"] = project.version
-                manifest.attributes["Implementation-Vendor"] = "New Relic, Inc"
+                manifest {
+                    attributes(mapOf(
+                            "Implementation-Version" to project.version,
+                            "Implementation-Vendor" to "New Relic, Inc."
+                    ))
+                }
             }
         }
         val useLocalSonatype = project.properties["useLocalSonatype"] == "true"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
-buildscript {
-    dependencies {
-        classpath("gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8")
-    }
-}
+import com.newrelic.telemetry.gradle.configureRepositories
+import com.newrelic.telemetry.gradle.configuredPom
 
 plugins {
     java
@@ -65,52 +62,10 @@ listOf(":telemetry", ":telemetry-http-okhttp", ":telemetry-http-java11").forEach
                     from(components["java"])
                     artifact(tasks["sourcesJar"])
                     artifact(tasks["javadocJar"])
-                    pom {
-                        name.set(project.name)
-                        description.set("Used to send telemetry data to New Relic")
-                        url.set("https://github.com/newrelic/newrelic-telemetry-sdk-java")
-                        licenses {
-                            license {
-                                name.set("The Apache License, Version 2.0")
-                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                                distribution.set("repo")
-                            }
-                        }
-                        developers {
-                            developer {
-                                id.set("newrelic")
-                                name.set("New Relic")
-                                email.set("opensource@newrelic.com")
-                            }
-                        }
-                        scm {
-                            url.set("git@github.com:newrelic/newrelic-telemetry-sdk-java.git")
-                            connection.set("scm:git:git@github.com:newrelic/newrelic-telemetry-sdk-java.git")
-                        }
-                    }
+                    configuredPom(project)
                 }
             }
-            repositories {
-                maven {
-                    if (useLocalSonatype) {
-                        val releasesRepoUrl = uri("http://localhost:8081/repository/maven-releases/")
-                        val snapshotsRepoUrl = uri("http://localhost:8081/repository/maven-snapshots/")
-                        url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-                    }
-                    else {
-                        val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                        val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-                        url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-                        configure<SigningExtension> {
-                            sign(publications["mavenJava"])
-                        }
-                    }
-                    credentials {
-                        username = project.properties["sonatypeUsername"] as String?
-                        password = project.properties["sonatypePassword"] as String?
-                    }
-                }
-            }
+            configureRepositories(project, useLocalSonatype, "mavenJava")
         }
     }
 }

--- a/buildSrc/src/main/java/com/newrelic/telemetry/gradle/ConfigurePom.kt
+++ b/buildSrc/src/main/java/com/newrelic/telemetry/gradle/ConfigurePom.kt
@@ -1,0 +1,29 @@
+package com.newrelic.telemetry.gradle
+
+import org.gradle.api.Project
+
+fun org.gradle.api.publish.maven.MavenPublication.configuredPom(project: Project) {
+    pom {
+        name.set(project.name)
+        description.set("Used to send telemetry data to New Relic")
+        url.set("https://github.com/newrelic/newrelic-telemetry-sdk-java")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("newrelic")
+                name.set("New Relic")
+                email.set("opensource@newrelic.com")
+            }
+        }
+        scm {
+            url.set("git@github.com:newrelic/newrelic-telemetry-sdk-java.git")
+            connection.set("scm:git:git@github.com:newrelic/newrelic-telemetry-sdk-java.git")
+        }
+    }
+}

--- a/buildSrc/src/main/java/com/newrelic/telemetry/gradle/ConfigureRepositories.kt
+++ b/buildSrc/src/main/java/com/newrelic/telemetry/gradle/ConfigureRepositories.kt
@@ -1,0 +1,32 @@
+package com.newrelic.telemetry.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+
+fun PublishingExtension.configureRepositories(project: Project, useLocalSonatype: Boolean, publicationName: String) {
+    val publishing = this;
+    repositories {
+        maven {
+            if (useLocalSonatype) {
+                val releasesRepoUrl = project.uri("http://localhost:8081/repository/maven-releases/")
+                val snapshotsRepoUrl = project.uri("http://localhost:8081/repository/maven-snapshots/")
+                url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+            }
+            else {
+                val releasesRepoUrl = project.uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                val snapshotsRepoUrl = project.uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                project.configure<SigningExtension> {
+                    this.sign(publishing.publications[publicationName])
+                }
+            }
+            credentials {
+                username = project.properties["sonatypeUsername"] as String?
+                password = project.properties["sonatypePassword"] as String?
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Here is where we manage the version
-releaseVersion=0.5.1
+releaseVersion=0.6.0-SNAPSHOT
 
 # Set this to true to enable using a local sonatype (for debugging publishing issues)
 # Start a local sonatype in docker with this command:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Aug 12 08:46:16 PDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/telemetry_core/build.gradle.kts
+++ b/telemetry_core/build.gradle.kts
@@ -4,10 +4,10 @@ import com.newrelic.telemetry.gradle.configuredPom
 
 plugins {
     java
+    id("java-library")
     id("com.github.johnrengelman.shadow") version "5.2.0"
 }
 
-apply(plugin = "java-library")
 apply(plugin = "maven-publish")
 apply(plugin = "signing")
 
@@ -25,9 +25,11 @@ configure<JavaPluginConvention> {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+configurations["shadow"].extendsFrom(configurations["api"])
+
 dependencies {
-    "api"("org.slf4j:slf4j-api:${Versions.slf4j}")
-    compile("com.google.code.gson:gson:${Versions.gson}")
+    api("org.slf4j:slf4j-api:${Versions.slf4j}")
+    implementation("com.google.code.gson:gson:${Versions.gson}")
 
     testImplementation("org.slf4j:slf4j-simple:${Versions.slf4j}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
@@ -50,9 +52,12 @@ val sourcesJar by tasks.creating(Jar::class) {
 
 tasks {
     "shadowJar"(ShadowJar::class) {
-        classifier = ""
+        archiveClassifier.set("")
         dependencies {
             exclude(dependency("org.slf4j:slf4j-api:${Versions.slf4j}"))
+        }
+        manifest {
+            attributes(mapOf("Implementation-Version" to project.version, "Implementation-Vendor" to "New Relic, Inc."))
         }
         relocate("com.google.gson", "com.newrelic.relocated")
         minimize()


### PR DESCRIPTION
Fixes #157 

There's really only a small necessary change to publish the shadow jar instead of the regular jar. However, because the publication is defined at the root, we have to duplicate that configuration. Extracting the methods from the root gradle was the first step.

Then I updated gradle to 6.3 from 5.4.

Then I copied the necessary code and tasks into `telemetry-core` project, and changed the line to `project.shadow.component(this)` instead of `from(components["java"])`.

Then I tweaked the shadow configuration:
1. In order to be declared as a pom-level dependency, any excluded dependencies have to end up in the `shadow` configuration. Since the `api` configuration has the same stuff, I can make `shadow` incorporate everything in `api`.
2. `compile` configuration is deprecated, so I switched it to `implementation`.
3. ~I disabled the `jar` task since it produces bad jars.~ update: I backed out this change because it was breaking the okhttp tests with NoClassDefFound ... ????
4. I changed the classifier to `archiveClassifier` because the former is deprecated

Then I made the root `build.gradle.kts` use the factored out methods from the first step.

Then I moved from `apply plugin` to `plugins`. The former is the old-style (or subproject) way of applying plugins to a build.