### PR TITLE
build PRs with github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,22 @@
+name: Java PR build (gradle)
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Check formatting
+      run: ./gradlew verifyGoogleJavaFormat
+    - name: Check build and test
+      run: ./gradlew check javadoc
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,7 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
-pr:
-  branches:
-    include:
-      - '*'  # must quote since "*" is a YAML reserved character; we want a string
+pr: none
 
 trigger:
   - master

--- a/telemetry_examples/build.gradle.kts
+++ b/telemetry_examples/build.gradle.kts
@@ -22,6 +22,12 @@ dependencies {
     runtimeOnly("org.slf4j:slf4j-simple:${Versions.slf4j}")
 }
 
+tasks {
+    javadoc {
+        options.encoding = "UTF-8"
+    }
+}
+
 exampleClassTask("com.newrelic.telemetry.count.CountExample")
 exampleClassTask("com.newrelic.telemetry.gauge.GaugeExample")
 exampleClassTask("com.newrelic.telemetry.summary.SummaryExample")


### PR DESCRIPTION
This should disable the PR azure action and replace it with a GitHub action.  It's not great to be split (publish still on Azure) but hopefully this is a step along the path of #170.