### PR TITLE
use daemon threads in telemetryclient

### DIFF
--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class TelemetryClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(TelemetryClient.class);
+  private static final long DEFAULT_SHUTDOWN_SECONDS = 3L;
 
   private final EventBatchSender eventBatchSender;
   private final MetricBatchSender metricBatchSender;
@@ -62,11 +63,12 @@ public class TelemetryClient {
       SpanBatchSender spanBatchSender,
       EventBatchSender eventBatchSender,
       LogBatchSender logBatchSender) {
-    this.metricBatchSender = metricBatchSender;
-    this.spanBatchSender = spanBatchSender;
-    this.eventBatchSender = eventBatchSender;
-    this.logBatchSender = logBatchSender;
-    this.shutdownSeconds = 3L;
+    this(
+        metricBatchSender,
+        spanBatchSender,
+        eventBatchSender,
+        logBatchSender,
+        DEFAULT_SHUTDOWN_SECONDS);
   }
 
   /**
@@ -223,7 +225,8 @@ public class TelemetryClient {
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {
-        LOG.error("interrupted graceful shutdown", e);
+      Thread.currentThread().interrupt();
+      LOG.error("interrupted graceful shutdown", e);
     }
   }
 

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -46,7 +46,7 @@ public class TelemetryClient {
     thread.setDaemon(true);
     return thread;
   });
-  private final long shutdownSeconds = 3;
+  private final long shutdownSeconds;
 
   /**
    * Create a new TelemetryClient instance, with four senders. Note that if you don't intend to send
@@ -66,6 +66,28 @@ public class TelemetryClient {
     this.spanBatchSender = spanBatchSender;
     this.eventBatchSender = eventBatchSender;
     this.logBatchSender = logBatchSender;
+    this.shutdownSeconds = 3L;
+  }
+
+  /**
+   * Create a new TelemetryClient instance, with three senders and seconds to wait for shutdown.
+   *
+   * @param metricBatchSender The sender for dimensional metrics.
+   * @param spanBatchSender The sender for distributed tracing spans.
+   * @param eventBatchSender The sender for custom events
+   * @param shutdownSeconds num of seconds to wait for graceful shutdown of its executor
+   */
+  public TelemetryClient(
+      MetricBatchSender metricBatchSender,
+      SpanBatchSender spanBatchSender,
+      EventBatchSender eventBatchSender,
+      LogBatchSender logBatchSender,
+      long shutdownSeconds) {
+    this.metricBatchSender = metricBatchSender;
+    this.spanBatchSender = spanBatchSender;
+    this.eventBatchSender = eventBatchSender;
+    this.logBatchSender = logBatchSender;
+    this.shutdownSeconds = shutdownSeconds;
   }
 
   /**

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -46,6 +46,7 @@ public class TelemetryClient {
     thread.setDaemon(true);
     return thread;
   });
+  private final long shutdownSeconds = 3;
 
   /**
    * Create a new TelemetryClient instance, with four senders. Note that if you don't intend to send
@@ -194,6 +195,14 @@ public class TelemetryClient {
   public void shutdown() {
     LOG.info("Shutting down the TelemetryClient background Executor");
     executor.shutdown();
+    try {
+      if (!executor.awaitTermination(shutdownSeconds, TimeUnit.SECONDS)) {
+        LOG.warn("couldn't shutdown within timeout");
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+        LOG.error("interrupted graceful shutdown", e);
+    }
   }
 
   /**

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -267,7 +267,6 @@ public class TelemetryClient {
         metricBatchSender, spanBatchSender, eventBatchSender, logBatchSender);
   }
 
-
   /**
    * Create ScheduledExecutorService from a parameter given by constructor
    *
@@ -275,10 +274,11 @@ public class TelemetryClient {
    * @return ScheduledExecutorService
    */
   private static ScheduledExecutorService buildExecutorService(boolean useDaemonThread) {
-    return Executors.newSingleThreadScheduledExecutor(r -> {
-      Thread thread = new Thread(r);
-      thread.setDaemon(useDaemonThread);
-      return thread;
-    });
+    return Executors.newSingleThreadScheduledExecutor(
+        r -> {
+          Thread thread = new Thread(r);
+          thread.setDaemon(useDaemonThread);
+          return thread;
+        });
   }
 }

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -41,8 +41,11 @@ public class TelemetryClient {
   private final MetricBatchSender metricBatchSender;
   private final SpanBatchSender spanBatchSender;
   private final LogBatchSender logBatchSender;
-
-  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+    Thread thread = new Thread(r);
+    thread.setDaemon(true);
+    return thread;
+  });
 
   /**
    * Create a new TelemetryClient instance, with four senders. Note that if you don't intend to send

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class TelemetryClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(TelemetryClient.class);
-  private static final long DEFAULT_SHUTDOWN_SECONDS = 3L;
+  private static final int DEFAULT_SHUTDOWN_SECONDS = 3;
   private static final boolean DEFAULT_IS_DAEMON = true;
 
   private final EventBatchSender eventBatchSender;
@@ -70,7 +70,7 @@ public class TelemetryClient {
   }
 
   /**
-   * Create a new TelemetryClient instance, with three senders and seconds to wait for shutdown.
+   * Create a new TelemetryClient instance, with four senders and seconds to wait for shutdown.
    *
    * @param metricBatchSender The sender for dimensional metrics.
    * @param spanBatchSender The sender for distributed tracing spans.
@@ -83,7 +83,7 @@ public class TelemetryClient {
       SpanBatchSender spanBatchSender,
       EventBatchSender eventBatchSender,
       LogBatchSender logBatchSender,
-      long shutdownSeconds,
+      int shutdownSeconds,
       boolean useDaemonThread) {
     this.metricBatchSender = metricBatchSender;
     this.spanBatchSender = spanBatchSender;

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -225,8 +225,8 @@ public class TelemetryClient {
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
       LOG.error("interrupted graceful shutdown", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -43,7 +43,7 @@ public class TelemetryClient {
   private final MetricBatchSender metricBatchSender;
   private final SpanBatchSender spanBatchSender;
   private final ScheduledExecutorService executor;
-  private final long shutdownSeconds;
+  private final int shutdownSeconds;
   private final LogBatchSender logBatchSender;
 
   /**
@@ -75,6 +75,7 @@ public class TelemetryClient {
    * @param metricBatchSender The sender for dimensional metrics.
    * @param spanBatchSender The sender for distributed tracing spans.
    * @param eventBatchSender The sender for custom events
+   * @param logBatchSender The sender for log entries.
    * @param shutdownSeconds num of seconds to wait for graceful shutdown of its executor
    * @param useDaemonThread A flag to decide user-threads or daemon-threads
    */


### PR DESCRIPTION
related issue: https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/167

## Background
When TelemetryClient is getting 429 from NewRelic, it is caught into loop like below:

1. sendWithErrorHandling
2. retry
3. scheduleBatchSend
4. sendWithErrorHandling

In this flow, TelemetryClient doesn't consider maxRetries.

and this flow is executed in non-daemon threads(user threads), so while getting 429, TelemetryClient prevents JVM from shutting down.

This PR fixes the latter issue.

## Change
This PR just changes executor of TelemetryClient into one which uses ThreadFactory and set its threads as daemon threads.