### PR TITLE
fix namespace in build.gradle.kts for example tasks

### DIFF
--- a/telemetry_examples/README.md
+++ b/telemetry_examples/README.md
@@ -39,7 +39,7 @@ errors in the recommended way.
 ### Running the examples
 
 You can run the examples using gradle tasks.  You'll need your [New Relic Event Insert API Key](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register).
-Provide the API key as the `-PapiKey` property and run the gradle task in the usual way, as shown below.
+Provide the API key as the `-PapiKey=<your-api-key` property and run the gradle task in the usual way, as shown below.
 The command below will run the BoundaryExample class.
 
 `./gradlew telemetry_examples:BoundaryExample -PapiKey=<Your Insert API Key>`

--- a/telemetry_examples/README.md
+++ b/telemetry_examples/README.md
@@ -39,7 +39,7 @@ errors in the recommended way.
 ### Running the examples
 
 You can run the examples using gradle tasks.  You'll need your [New Relic Event Insert API Key](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register).
-Provide the API key as the `-PapiKey=<your-api-key` property and run the gradle task in the usual way, as shown below.
+Provide the API key as the `-PapiKey=<your-api-key>` property and run the gradle task in the usual way, as shown below.
 The command below will run the BoundaryExample class.
 
 `./gradlew telemetry_examples:BoundaryExample -PapiKey=<Your Insert API Key>`

--- a/telemetry_examples/README.md
+++ b/telemetry_examples/README.md
@@ -35,3 +35,12 @@ that can be fed a `SpanBatch`.
 
 This is an example of how to use the provided `com.newrelic.telemetry.TelemetryClient` to handle
 errors in the recommended way.
+
+### Running the examples
+
+You can run the examples using gradle tasks.  You'll need your [New Relic Event Insert API Key](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register).
+Provide the API key as the `-PapiKey` property and run the gradle task in the usual way, as shown below.
+The command below will run the BoundaryExample class.
+
+`./gradlew telemetry_examples:BoundaryExample -PapiKey=<Your Insert API Key>`
+

--- a/telemetry_examples/build.gradle.kts
+++ b/telemetry_examples/build.gradle.kts
@@ -28,8 +28,12 @@ tasks {
     }
 }
 
-exampleClassTask("com.newrelic.telemetry.examples.CountExample")
-exampleClassTask("com.newrelic.telemetry.examples.GaugeExample")
-exampleClassTask("com.newrelic.telemetry.examples.SummaryExample")
 exampleClassTask("com.newrelic.telemetry.examples.BoundaryExample")
 exampleClassTask("com.newrelic.telemetry.examples.ConfigurationExamples")
+exampleClassTask("com.newrelic.telemetry.examples.CountExample")
+exampleClassTask("com.newrelic.telemetry.examples.EventExample")
+exampleClassTask("com.newrelic.telemetry.examples.GaugeExample")
+exampleClassTask("com.newrelic.telemetry.examples.LogExample")
+exampleClassTask("com.newrelic.telemetry.examples.SpanExample")
+exampleClassTask("com.newrelic.telemetry.examples.SummaryExample")
+exampleClassTask("com.newrelic.telemetry.examples.TelemetryClientExample")

--- a/telemetry_examples/build.gradle.kts
+++ b/telemetry_examples/build.gradle.kts
@@ -28,7 +28,8 @@ tasks {
     }
 }
 
-exampleClassTask("com.newrelic.telemetry.count.CountExample")
-exampleClassTask("com.newrelic.telemetry.gauge.GaugeExample")
-exampleClassTask("com.newrelic.telemetry.summary.SummaryExample")
-exampleClassTask("com.newrelic.telemetry.boundaries.BoundaryExample")
+exampleClassTask("com.newrelic.telemetry.examples.CountExample")
+exampleClassTask("com.newrelic.telemetry.examples.GaugeExample")
+exampleClassTask("com.newrelic.telemetry.examples.SummaryExample")
+exampleClassTask("com.newrelic.telemetry.examples.BoundaryExample")
+exampleClassTask("com.newrelic.telemetry.examples.ConfigurationExamples")


### PR DESCRIPTION
This change makes it so that you can use gradle tasks to run the examples using:
`./gradlew telemetry_examples:BoundaryExample -PapiKey=<key>`

example previous name space used in the build.gradle.kts file was
`com.newrelic.telemetry.count.BoundaryExample`
but the actual package and class name is:
`com.newrelic.telemetry.examples.BoundaryExample`


This doesn't update the documentation to show how to run the examples with gradle.  I will submit a separate PR to update the documentation, or if you prefer I can add that to this PR.

