### PR TITLE
Fix the default metric URL to point at the metric API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 - Enable adding additional user agent information to the HTTP requests made by the SDK.
 
+## [0.6.1] - 2020-06-18
+- Fix the default metric API URL to point at the metric API
+
 ## [0.6.0] - 2020-05-28
 - Add initial preliminary support for Logs data type
 - Simplified creation TelemetryClient and friends

--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ Maven dependencies:
     <dependency>
       <groupId>com.newrelic.telemetry</groupId>
       <artifactId>telemetry</artifactId>
-      <version>0.6.0</version>
+      <version>0.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.newrelic.telemetry</groupId>
       <artifactId>telemetry-http-okhttp</artifactId>
-      <version>0.6.0</version>
+      <version>0.6.1</version>
     </dependency>
 ```
 
 Gradle dependencies: 
 
 ```
-compile("com.newrelic.telemetry:telemetry:0.6.0")
-compile("com.newrelic.telemetry:telemetry-http-okhttp:0.6.0")
+compile("com.newrelic.telemetry:telemetry:0.6.1")
+compile("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
 ```
 
 Take a look at the example code in the [telemetry_examples](telemetry_examples) module. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Here is where we manage the version
-releaseVersion=0.7.0-SNAPSHOT
+releaseVersion=0.6.1
 
 # Set this to true to enable using a local sonatype (for debugging publishing issues)
 # Start a local sonatype in docker with this command:

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class MetricBatchSender {
 
   private static final String METRICS_PATH = "/metric/v1";
-  private static final String DEFAULT_URL = "https://trace-api.newrelic.com/";
+  private static final String DEFAULT_URL = "https://metric-api.newrelic.com/";
 
   private static final Logger logger = LoggerFactory.getLogger(MetricBatchSender.class);
 


### PR DESCRIPTION
And, release 0.6.1