### PR TITLE
Have the TelemetryClient be less noisy after being shut down 

### DIFF
--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -17,15 +17,14 @@ import com.newrelic.telemetry.metrics.MetricBatch;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class should be the go-to spot for sending telemetry to New Relic. It includes the canonical

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -17,14 +17,15 @@ import com.newrelic.telemetry.metrics.MetricBatch;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class should be the go-to spot for sending telemetry to New Relic. It includes the canonical
@@ -174,12 +175,6 @@ public class TelemetryClient {
 
   private void sendWithErrorHandling(
       BatchSender batchSender, TelemetryBatch<? extends Telemetry> batch, Backoff backoff) {
-    if (executor.isTerminated()) {
-      LOG.info(
-          "TelemetryClient background Executor is terminated. Batch not sent",
-          batch.getClass().getSimpleName());
-      return;
-    }
     try {
       batchSender.sendBatch(batch);
       LOG.debug("Telemetry batch sent");


### PR DESCRIPTION
This is a start for issue #176 

I think this small change is all that is needed. 
If the TelemetryClient executor is shutdown 
log that the batch was not sent.
log some info about the batch
return before attempting to send.

I will also add a test to this pr.

