### PR TITLE
When an IOException occurs, have the BatchDataSender only log the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
-- Enable adding additional user agent information to the HTTP requests made by the SDK.
+- Quieter logging when IOExceptions occur during data transmission.
 
 ## [0.6.1] - 2020-06-18
 - Fix the default metric API URL to point at the metric API

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/ResponseException.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/ResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.newrelic.telemetry.exceptions;
@@ -30,5 +30,9 @@ public abstract class ResponseException extends Exception {
 
   ResponseException(String message) {
     super(message);
+  }
+
+  ResponseException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/RetryWithBackoffException.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/RetryWithBackoffException.java
@@ -14,7 +14,7 @@ public class RetryWithBackoffException extends ResponseException {
     super("The New Relic API suggests backing off exponentially on this request.");
   }
 
-  public RetryWithBackoffException(Throwable cause) {
-    super("The New Relic API suggests backing off exponentially on this request.", cause);
+  public RetryWithBackoffException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/RetryWithBackoffException.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/exceptions/RetryWithBackoffException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.newrelic.telemetry.exceptions;
@@ -12,5 +12,9 @@ public class RetryWithBackoffException extends ResponseException {
 
   public RetryWithBackoffException() {
     super("The New Relic API suggests backing off exponentially on this request.");
+  }
+
+  public RetryWithBackoffException(Throwable cause) {
+    super("The New Relic API suggests backing off exponentially on this request.", cause);
   }
 }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.newrelic.telemetry.transport;
@@ -149,8 +149,9 @@ public class BatchDataSender {
       }
     } catch (IOException e) {
       logger.warn(
-          "IOException while trying to send data to New Relic. Batch retry recommended.", e);
-      throw new RetryWithBackoffException();
+          "IOException (message: {}) while trying to send data to New Relic. Batch retry recommended.",
+          e.getMessage());
+      throw new RetryWithBackoffException(e);
     }
   }
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -151,7 +151,11 @@ public class BatchDataSender {
       logger.warn(
           "IOException (message: {}) while trying to send data to New Relic. Batch retry recommended.",
           e.getMessage());
-      throw new RetryWithBackoffException(e);
+      throw new RetryWithBackoffException(
+          "IOException (message: {"
+              + e.getMessage()
+              + "}) while trying to send data to New Relic. Batch retry recommended.",
+          e);
     }
   }
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.newrelic.telemetry.transport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -13,8 +15,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.http.HttpResponse;
+import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
@@ -64,5 +68,32 @@ class BatchDataSenderTest {
     Response response = testClass.send("{}");
 
     assertEquals(new Response(202, "OK", "yepyep"), response);
+  }
+
+  @Test
+  void testCapturingCaseOfIoException() throws Exception {
+    URL endpointURl = new URL("http://foo.com");
+    HttpPoster httpPoster = mock(HttpPoster.class);
+    Map<String, String> headers =
+        ImmutableMap.of(
+            "User-Agent", "NewRelic-Java-TelemetrySDK/UnknownVersion",
+            "Api-Key", "api-key",
+            "Content-Encoding", "gzip");
+    // note: not testing the gzipping here
+    when(httpPoster.post(
+            eq(endpointURl), eq(headers), any(), eq("application/json; charset=utf-8")))
+        .thenThrow(new IOException("timeout"));
+
+    BatchDataSender testClass =
+        new BatchDataSender(httpPoster, "api-key", endpointURl, false, null);
+
+    RetryWithBackoffException exception =
+        assertThrows(
+            RetryWithBackoffException.class,
+            () -> testClass.send("{}"),
+            "Should have thrown a retry with backoff");
+
+    assertNotNull(exception.getCause());
+    assertEquals("timeout", exception.getCause().getMessage());
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
@@ -28,7 +28,7 @@ class BatchDataSenderTest {
 
   @Test
   void testSend_noSecondaryUserAgent() throws Exception {
-    URL endpointURl = new URL("http://foo.com");
+    URL endpointURl = new URL("http://example.com");
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(
@@ -50,7 +50,7 @@ class BatchDataSenderTest {
 
   @Test
   void testSecondaryUserAgent() throws Exception {
-    URL endpointURl = new URL("http://foo.com");
+    URL endpointURl = new URL("http://example.com");
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(
@@ -72,7 +72,7 @@ class BatchDataSenderTest {
 
   @Test
   void testCapturingCaseOfIoException() throws Exception {
-    URL endpointURl = new URL("http://foo.com");
+    URL endpointURl = new URL("http://example.com");
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(


### PR DESCRIPTION
But, include the exception in the one that is rethrown in case someone higher up wants to log the details.

This should quiet things down a bit when there are transient network blips. 
