### PR TITLE
add create() overload on TelemetryClient

### DIFF
--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -248,29 +248,22 @@ public class TelemetryClient {
    */
   public static TelemetryClient create(
       Supplier<HttpPoster> httpPosterCreator, String insertApiKey) {
-    MetricBatchSender metricBatchSender =
-        MetricBatchSender.create(
-            MetricBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
-                .configureWith(insertApiKey)
-                .build());
+    return create(httpPosterCreator, new BaseConfig(insertApiKey));
+  }
 
-    SpanBatchSender spanBatchSender =
-        SpanBatchSender.create(
-            SpanBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
-                .configureWith(insertApiKey)
-                .build());
-
-    EventBatchSender eventBatchSender =
-        EventBatchSender.create(
-            EventBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
-                .configureWith(insertApiKey)
-                .build());
-
-    LogBatchSender logBatchSender =
-        LogBatchSender.create(
-            LogBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
-                .configureWith(insertApiKey)
-                .build());
+  /**
+   * Create a fully operational {@link TelemetryClient} settings from a BaseConfig instance
+   *
+   * @param httpPosterCreator A {@link Supplier} used to create an {@link HttpPoster} instance.
+   * @param baseConfig the base configuration
+   * @return A fully operational TelemetryClient instance.
+   */
+  public static TelemetryClient create(
+      Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
+    MetricBatchSender metricBatchSender = MetricBatchSender.create(httpPosterCreator, baseConfig);
+    SpanBatchSender spanBatchSender = SpanBatchSender.create(httpPosterCreator, baseConfig);
+    EventBatchSender eventBatchSender = EventBatchSender.create(httpPosterCreator, baseConfig);
+    LogBatchSender logBatchSender = LogBatchSender.create(httpPosterCreator, baseConfig);
     return new TelemetryClient(
         metricBatchSender, spanBatchSender, eventBatchSender, logBatchSender);
   }

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -252,7 +252,7 @@ public class TelemetryClient {
   }
 
   /**
-   * Create a fully operational {@link TelemetryClient} settings from a BaseConfig instance
+   * Create a fully operational {@link TelemetryClient} from a BaseConfig instance
    *
    * @param httpPosterCreator A {@link Supplier} used to create an {@link HttpPoster} instance.
    * @param baseConfig the base configuration

--- a/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
@@ -31,7 +31,6 @@ import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
-
 import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
@@ -44,11 +43,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 class TelemetryClientTest {
@@ -201,11 +198,11 @@ class TelemetryClientTest {
     Supplier<HttpPoster> posterSupplier = () -> poster;
     Response expected = new Response(202, "okey", "bb");
     HttpResponse httpResponse =
-            new HttpResponse(
-                    expected.getBody(),
-                    expected.getStatusCode(),
-                    expected.getStatusMessage(),
-                    new HashMap<>());
+        new HttpResponse(
+            expected.getBody(),
+            expected.getStatusCode(),
+            expected.getStatusMessage(),
+            new HashMap<>());
     CountDownLatch latch = new CountDownLatch(1);
     Event event = new Event("flim", new Attributes().put("x", "y"));
     EventBatch metrics = new EventBatch(singletonList(event), new Attributes().put("a", "b"));
@@ -215,10 +212,12 @@ class TelemetryClientTest {
 
     ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
     when(poster.post(eq(url), headersCaptor.capture(), isA(byte[].class), anyString()))
-            .thenAnswer((Answer<HttpResponse>) invocation -> {
-              latch.countDown();
-              return httpResponse;
-            });
+        .thenAnswer(
+            (Answer<HttpResponse>)
+                invocation -> {
+                  latch.countDown();
+                  return httpResponse;
+                });
 
     client.sendBatch(metrics);
     assertTrue(latch.await(2, TimeUnit.SECONDS));

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
@@ -1,33 +1,70 @@
 package com.newrelic.telemetry;
 
+/** A configuration class for several common settings. */
 public class BaseConfig {
 
   private final String apiKey;
   private final boolean auditLoggingEnabled;
   private final String secondaryUserAgent;
 
+  /**
+   * Create a new BaseConfig with a required apiKey. Audit logging will default to disabled and
+   * there will be no secondary user agent.
+   *
+   * @param apiKey the API insert key required for the sdk to send telemetry.
+   */
   public BaseConfig(String apiKey) {
     this(apiKey, false);
   }
 
+  /**
+   * Create a new BaseConfig with a required apiKey and a setting for auditLoggingEnabled. If
+   * auditLoggingEnabled is true, the SDK will be extra verbose, which can help when
+   * troubleshooting. There will be no secondary user agent.
+   *
+   * @param apiKey The API insert key required for the sdk to send telemetry.
+   * @param auditLoggingEnabled true to turn on audit/verbose logging
+   */
   public BaseConfig(String apiKey, boolean auditLoggingEnabled) {
     this(apiKey, auditLoggingEnabled, null);
   }
 
+  /**
+   * Creates a new BaseConfig.
+   *
+   * @param apiKey the API insert key required for the sdk to send telemetry.
+   * @param auditLoggingEnabled true to turn on audit/verbose logging
+   * @param secondaryUserAgent an extra string to put into the HTTP user agent
+   */
   public BaseConfig(String apiKey, boolean auditLoggingEnabled, String secondaryUserAgent) {
     this.apiKey = apiKey;
     this.auditLoggingEnabled = auditLoggingEnabled;
     this.secondaryUserAgent = secondaryUserAgent;
   }
 
+  /**
+   * Returns the New Relic api insert key
+   *
+   * @return the New Relic api key
+   */
   public String getApiKey() {
     return apiKey;
   }
 
+  /**
+   * Returns true if verbose audit logging is enabled
+   *
+   * @return true if verbose audit logging is enabled
+   */
   public boolean isAuditLoggingEnabled() {
     return auditLoggingEnabled;
   }
 
+  /**
+   * Returns the secondary http user agent string
+   *
+   * @return the secodary http user agent string, which may be null
+   */
   public String getSecondaryUserAgent() {
     return secondaryUserAgent;
   }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
@@ -42,29 +42,17 @@ public class BaseConfig {
     this.secondaryUserAgent = secondaryUserAgent;
   }
 
-  /**
-   * Returns the New Relic api insert key
-   *
-   * @return the New Relic api key
-   */
+  /** @return the New Relic api key */
   public String getApiKey() {
     return apiKey;
   }
 
-  /**
-   * Returns true if verbose audit logging is enabled
-   *
-   * @return true if verbose audit logging is enabled
-   */
+  /** @return true if verbose audit logging is enabled */
   public boolean isAuditLoggingEnabled() {
     return auditLoggingEnabled;
   }
 
-  /**
-   * Returns the secondary http user agent string
-   *
-   * @return the secodary http user agent string, which may be null
-   */
+  /** @return the secondary http user agent string, which may be null */
   public String getSecondaryUserAgent() {
     return secondaryUserAgent;
   }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/BaseConfig.java
@@ -1,0 +1,34 @@
+package com.newrelic.telemetry;
+
+public class BaseConfig {
+
+  private final String apiKey;
+  private final boolean auditLoggingEnabled;
+  private final String secondaryUserAgent;
+
+  public BaseConfig(String apiKey) {
+    this(apiKey, false);
+  }
+
+  public BaseConfig(String apiKey, boolean auditLoggingEnabled) {
+    this(apiKey, auditLoggingEnabled, null);
+  }
+
+  public BaseConfig(String apiKey, boolean auditLoggingEnabled, String secondaryUserAgent) {
+    this.apiKey = apiKey;
+    this.auditLoggingEnabled = auditLoggingEnabled;
+    this.secondaryUserAgent = secondaryUserAgent;
+  }
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  public boolean isAuditLoggingEnabled() {
+    return auditLoggingEnabled;
+  }
+
+  public String getSecondaryUserAgent() {
+    return secondaryUserAgent;
+  }
+}

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/EventBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/EventBatchSenderFactory.java
@@ -30,6 +30,14 @@ public interface EventBatchSenderFactory {
     return EventBatchSender.create(configuration.build());
   }
 
+  /**
+   * Creates a new SenderConfigurationBuilder to help with constructing a EventBatchSender. This
+   * builder is configured with data from the BaseConfig, including the apiKey, audit logging
+   * dis/enabled, and secondary user agent (which may be null).
+   *
+   * @param baseConfig a BaseConfig with settings to apply to the new builder
+   * @return a new SenderConfigurationBuilder with the config applied
+   */
   default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
     return configureWith(baseConfig.getApiKey())
         .secondaryUserAgent(baseConfig.getSecondaryUserAgent())

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/EventBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/EventBatchSenderFactory.java
@@ -30,6 +30,12 @@ public interface EventBatchSenderFactory {
     return EventBatchSender.create(configuration.build());
   }
 
+  default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
+    return configureWith(baseConfig.getApiKey())
+        .secondaryUserAgent(baseConfig.getSecondaryUserAgent())
+        .auditLoggingEnabled(baseConfig.isAuditLoggingEnabled());
+  }
+
   /**
    * Create a new {@link SenderConfigurationBuilder} with your New Relic Insights Insert API key.
    *

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
@@ -30,6 +30,14 @@ public interface LogBatchSenderFactory {
     return LogBatchSender.create(configuration.build());
   }
 
+  /**
+   * Creates a new SenderConfigurationBuilder to help with constructing a LogBatchSender. This
+   * builder is configured with data from the BaseConfig, including the apiKey, audit logging
+   * dis/enabled, and secondary user agent (which may be null).
+   *
+   * @param config a BaseConfig with settings to apply to the new builder
+   * @return a new SenderConfigurationBuilder with the config applied
+   */
   default SenderConfigurationBuilder configureWith(BaseConfig config) {
     return configureWith(config.getApiKey())
         .auditLoggingEnabled(config.isAuditLoggingEnabled())

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/LogBatchSenderFactory.java
@@ -30,6 +30,13 @@ public interface LogBatchSenderFactory {
     return LogBatchSender.create(configuration.build());
   }
 
+  default SenderConfigurationBuilder configureWith(BaseConfig config) {
+    return configureWith(config.getApiKey())
+        .auditLoggingEnabled(config.isAuditLoggingEnabled())
+        .secondaryUserAgent(config.getSecondaryUserAgent())
+        .httpPoster(getPoster());
+  }
+
   /**
    * Create a new {@link SenderConfigurationBuilder} with your New Relic Insights Insert API key.
    *

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/MetricBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/MetricBatchSenderFactory.java
@@ -30,6 +30,12 @@ public interface MetricBatchSenderFactory {
     return MetricBatchSender.create(configuration.build());
   }
 
+  default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
+    return configureWith(baseConfig.getApiKey())
+        .auditLoggingEnabled(baseConfig.isAuditLoggingEnabled())
+        .secondaryUserAgent(baseConfig.getSecondaryUserAgent());
+  }
+
   /**
    * Create a new MetricBatchSenderBuilder with your New Relic Insights Insert API key.
    *

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/MetricBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/MetricBatchSenderFactory.java
@@ -30,6 +30,14 @@ public interface MetricBatchSenderFactory {
     return MetricBatchSender.create(configuration.build());
   }
 
+  /**
+   * Creates a new SenderConfigurationBuilder to help with constructing a MetricBatchSender. This
+   * builder is configured with data from the BaseConfig, including the apiKey, audit logging
+   * dis/enabled, and secondary user agent (which may be null).
+   *
+   * @param baseConfig a BaseConfig with settings to apply to the new builder
+   * @return a new SenderConfigurationBuilder with the config applied
+   */
   default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
     return configureWith(baseConfig.getApiKey())
         .auditLoggingEnabled(baseConfig.isAuditLoggingEnabled())

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -13,11 +13,9 @@ import java.net.URL;
 
 /** Configuration options for the various classes that send data to the New Relic ingest APIs. */
 public class SenderConfiguration {
-  private final String apiKey;
+  private final BaseConfig baseConfig;
   private final HttpPoster httpPoster;
   private final URL endpointUrl;
-  private final boolean auditLoggingEnabled;
-  private final String secondaryUserAgent;
 
   public SenderConfiguration(
       String apiKey,
@@ -25,15 +23,13 @@ public class SenderConfiguration {
       URL endpointUrl,
       boolean auditLoggingEnabled,
       String secondaryUserAgent) {
-    this.apiKey = apiKey;
     this.httpPoster = httpPoster;
     this.endpointUrl = endpointUrl;
-    this.auditLoggingEnabled = auditLoggingEnabled;
-    this.secondaryUserAgent = secondaryUserAgent;
+    this.baseConfig = new BaseConfig(apiKey, auditLoggingEnabled, secondaryUserAgent);
   }
 
   public String getApiKey() {
-    return apiKey;
+    return baseConfig.getApiKey();
   }
 
   public HttpPoster getHttpPoster() {
@@ -45,11 +41,11 @@ public class SenderConfiguration {
   }
 
   public boolean isAuditLoggingEnabled() {
-    return auditLoggingEnabled;
+    return baseConfig.isAuditLoggingEnabled();
   }
 
   public String getSecondaryUserAgent() {
-    return secondaryUserAgent;
+    return baseConfig.getSecondaryUserAgent();
   }
 
   public static SenderConfigurationBuilder builder(String defaultUrl, String basePath) {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SpanBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SpanBatchSenderFactory.java
@@ -30,6 +30,14 @@ public interface SpanBatchSenderFactory {
     return SpanBatchSender.create(configuration.build());
   }
 
+  /**
+   * Creates a new SenderConfigurationBuilder to help with constructing a SpanBatchSender. This
+   * builder is configured with data from the BaseConfig, including the apiKey, audit logging
+   * dis/enabled, and secondary user agent (which may be null).
+   *
+   * @param baseConfig a BaseConfig with settings to apply to the new builder
+   * @return a new SenderConfigurationBuilder with the config applied
+   */
   default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
     return configureWith(baseConfig.getApiKey())
         .auditLoggingEnabled(baseConfig.isAuditLoggingEnabled())

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SpanBatchSenderFactory.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SpanBatchSenderFactory.java
@@ -30,6 +30,12 @@ public interface SpanBatchSenderFactory {
     return SpanBatchSender.create(configuration.build());
   }
 
+  default SenderConfigurationBuilder configureWith(BaseConfig baseConfig) {
+    return configureWith(baseConfig.getApiKey())
+        .auditLoggingEnabled(baseConfig.isAuditLoggingEnabled())
+        .secondaryUserAgent(baseConfig.getSecondaryUserAgent());
+  }
+
   /**
    * Create a new SpanBatchSenderBuilder with your New Relic Insights Insert API key.
    *

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -104,6 +104,15 @@ public class EventBatchSender {
     return response;
   }
 
+  /**
+   * Creates a new EventBatchSender with the given supplier of HttpPoster impl and a BaseConfig
+   * instance, with all configuration NOT in BaseConfig being default.
+   *
+   * @param httpPosterCreator A supplier that returns an HttpPoster for this EventBatchSender to
+   *     use.
+   * @param baseConfig basic configuration for the sender
+   * @return a shiny new EventBatchSender instance
+   */
   public static EventBatchSender create(
       Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
     return EventBatchSender.create(

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -5,6 +5,8 @@
 
 package com.newrelic.telemetry.events;
 
+import com.newrelic.telemetry.BaseConfig;
+import com.newrelic.telemetry.EventBatchSenderFactory;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.SenderConfiguration.SenderConfigurationBuilder;
@@ -12,12 +14,14 @@ import com.newrelic.telemetry.TelemetryBatch;
 import com.newrelic.telemetry.events.json.EventBatchMarshaller;
 import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.exceptions.RetryWithSplitException;
+import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +102,14 @@ public class EventBatchSender {
     }
 
     return response;
+  }
+
+  public static EventBatchSender create(
+      Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
+    return EventBatchSender.create(
+        EventBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
+            .configureWith(baseConfig)
+            .build());
   }
 
   public static EventBatchSender create(SenderConfiguration configuration) {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -4,9 +4,12 @@
  */
 package com.newrelic.telemetry.logs;
 
+import com.newrelic.telemetry.BaseConfig;
+import com.newrelic.telemetry.LogBatchSenderFactory;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.logs.json.LogBatchMarshaller;
 import com.newrelic.telemetry.logs.json.LogJsonCommonBlockWriter;
@@ -14,6 +17,7 @@ import com.newrelic.telemetry.logs.json.LogJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
 import java.net.URL;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +63,14 @@ public class LogBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
     return sender.send(json);
+  }
+
+  public static LogBatchSender create(
+      Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
+    return create(
+        LogBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
+            .configureWith(baseConfig)
+            .build());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -65,6 +65,14 @@ public class LogBatchSender {
     return sender.send(json);
   }
 
+  /**
+   * Creates a new LogBatchSender with the given supplier of HttpPoster impl and a BaseConfig
+   * instance, with all configuration NOT in BaseConfig being default.
+   *
+   * @param httpPosterCreator A supplier that returns an HttpPoster for this LogBatchSender to use.
+   * @param baseConfig basic configuration for the sender
+   * @return a shiny new LogBatchSender instance
+   */
   public static LogBatchSender create(
       Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
     return create(

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -73,6 +73,15 @@ public class MetricBatchSender {
     return sender.send(json);
   }
 
+  /**
+   * Creates a new MetricBatchSender with the given supplier of HttpPoster impl and a BaseConfig
+   * instance, with all configuration NOT in BaseConfig being default.
+   *
+   * @param httpPosterCreator A supplier that returns an HttpPoster for this MetricBatchSender to
+   *     use.
+   * @param baseConfig basic configuration for the sender
+   * @return a shiny new MetricBatchSender instance
+   */
   public static MetricBatchSender create(
       Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
     return create(

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -4,10 +4,13 @@
  */
 package com.newrelic.telemetry.metrics;
 
+import com.newrelic.telemetry.BaseConfig;
+import com.newrelic.telemetry.MetricBatchSenderFactory;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.SenderConfiguration.SenderConfigurationBuilder;
 import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.metrics.json.MetricBatchJsonCommonBlockWriter;
 import com.newrelic.telemetry.metrics.json.MetricBatchJsonTelemetryBlockWriter;
@@ -16,6 +19,7 @@ import com.newrelic.telemetry.metrics.json.MetricToJson;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
 import java.net.URL;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +71,14 @@ public class MetricBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
     return sender.send(json);
+  }
+
+  public static MetricBatchSender create(
+      Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
+    return create(
+        MetricBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
+            .configureWith(baseConfig)
+            .build());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -4,9 +4,12 @@
  */
 package com.newrelic.telemetry.spans;
 
+import com.newrelic.telemetry.BaseConfig;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.SenderConfiguration;
+import com.newrelic.telemetry.SpanBatchSenderFactory;
 import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.json.AttributesJson;
 import com.newrelic.telemetry.spans.json.SpanBatchMarshaller;
 import com.newrelic.telemetry.spans.json.SpanJsonCommonBlockWriter;
@@ -14,6 +17,7 @@ import com.newrelic.telemetry.spans.json.SpanJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
 import java.net.URL;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +75,14 @@ public class SpanBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
     return sender.send(json);
+  }
+
+  public static SpanBatchSender create(
+      Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
+    return SpanBatchSender.create(
+        SpanBatchSenderFactory.fromHttpImplementation(httpPosterCreator)
+            .configureWith(baseConfig)
+            .build());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -77,6 +77,14 @@ public class SpanBatchSender {
     return sender.send(json);
   }
 
+  /**
+   * Creates a new SpanBatchSender with the given supplier of HttpPoster impl and a BaseConfig
+   * instance, with all configuration NOT in BaseConfig being default.
+   *
+   * @param httpPosterCreator A supplier that returns an HttpPoster for this SpanBatchSender to use.
+   * @param baseConfig basic configuration for the sender
+   * @return a shiny new SpanBatchSender instance
+   */
   public static SpanBatchSender create(
       Supplier<HttpPoster> httpPosterCreator, BaseConfig baseConfig) {
     return SpanBatchSender.create(

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/BaseConfigTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/BaseConfigTest.java
@@ -1,0 +1,19 @@
+package com.newrelic.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class BaseConfigTest {
+
+  @Test
+  void defaultAuditModeIsDisabled() {
+    assertFalse(new BaseConfig("1").isAuditLoggingEnabled());
+  }
+
+  @Test
+  void defaultSecondaryUserAgentIsNull() {
+    assertNull(new BaseConfig("1").getSecondaryUserAgent());
+    assertNull(new BaseConfig("1", true).getSecondaryUserAgent());
+  }
+}

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/EventBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/EventBatchSenderFactoryTest.java
@@ -4,18 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.newrelic.telemetry.http.HttpPoster;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class EventBatchSenderFactoryTest {
 
-  EventBatchSenderFactory factory;
-
-  @BeforeEach
-  void setup() {
-    HttpPoster poster = (url, headers, body, mediaType) -> null;
-    factory = () -> poster;
-  }
+  HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
+  EventBatchSenderFactory factory = () -> httpPoster;
 
   @Test
   void testWithBaseConfig() {

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/EventBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/EventBatchSenderFactoryTest.java
@@ -1,0 +1,29 @@
+package com.newrelic.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.newrelic.telemetry.http.HttpPoster;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EventBatchSenderFactoryTest {
+
+  EventBatchSenderFactory factory;
+
+  @BeforeEach
+  void setup() {
+    HttpPoster poster = (url, headers, body, mediaType) -> null;
+    factory = () -> poster;
+  }
+
+  @Test
+  void testWithBaseConfig() {
+    BaseConfig baseConfig = new BaseConfig("a", false, "b");
+    SenderConfiguration.SenderConfigurationBuilder builder = factory.configureWith(baseConfig);
+    SenderConfiguration result = builder.build();
+    assertEquals("a", result.getApiKey());
+    assertFalse(result.isAuditLoggingEnabled());
+    assertEquals("b", result.getSecondaryUserAgent());
+  }
+}

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/LogBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/LogBatchSenderFactoryTest.java
@@ -4,17 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.http.HttpPoster;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class LogBatchSenderFactoryTest {
-  LogBatchSenderFactory factory;
 
-  @BeforeEach
-  void setup() {
-    HttpPoster poster = (url, headers, body, mediaType) -> null;
-    factory = () -> poster;
-  }
+  HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
+  LogBatchSenderFactory factory = () -> httpPoster;
 
   @Test
   void testWithBaseConfig() {

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/LogBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/LogBatchSenderFactoryTest.java
@@ -1,20 +1,14 @@
-/*
- * Copyright 2020 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
 package com.newrelic.telemetry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.http.HttpPoster;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SpanBatchSenderFactoryTest {
-
-  SpanBatchSenderFactory factory;
+class LogBatchSenderFactoryTest {
+  LogBatchSenderFactory factory;
 
   @BeforeEach
   void setup() {
@@ -23,18 +17,12 @@ class SpanBatchSenderFactoryTest {
   }
 
   @Test
-  void testBuilders() {
-    assertNotNull(factory.configureWith("abc123"));
-    assertNotNull(factory.createBatchSender("abc123"));
-  }
-
-  @Test
-  void withBaseConfig() {
-    BaseConfig baseConfig = new BaseConfig("hey", true, "ttt");
+  void testWithBaseConfig() {
+    BaseConfig baseConfig = new BaseConfig("one", true, "twelve");
     SenderConfiguration.SenderConfigurationBuilder builder = factory.configureWith(baseConfig);
     SenderConfiguration result = builder.build();
-    assertEquals("hey", result.getApiKey());
+    assertEquals("one", result.getApiKey());
     assertTrue(result.isAuditLoggingEnabled());
-    assertEquals("ttt", result.getSecondaryUserAgent());
+    assertEquals("twelve", result.getSecondaryUserAgent());
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/MetricBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/MetricBatchSenderFactoryTest.java
@@ -4,19 +4,37 @@
  */
 package com.newrelic.telemetry;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.http.HttpPoster;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MetricBatchSenderFactoryTest {
 
+  MetricBatchSenderFactory factory;
+
+  @BeforeEach
+  void setup() {
+    HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
+    factory = () -> httpPoster;
+  }
+
   @Test
   void testBuilders() {
-    HttpPoster h = (url, headers, body, mediaType) -> null;
-    MetricBatchSenderFactory f = () -> h;
+    assertNotNull(factory.configureWith("abc123"));
+    assertNotNull(factory.createBatchSender("abc123"));
+  }
 
-    assertNotNull(f.configureWith("abc123"));
-    assertNotNull(f.createBatchSender("abc123"));
+  @Test
+  void configureWithBaseConfig() {
+    BaseConfig baseConfig = new BaseConfig("123", true, "flibber");
+    SenderConfiguration.SenderConfigurationBuilder builder = factory.configureWith(baseConfig);
+    SenderConfiguration result = builder.build();
+    assertEquals("123", result.getApiKey());
+    assertTrue(result.isAuditLoggingEnabled());
+    assertEquals("flibber", result.getSecondaryUserAgent());
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/MetricBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/MetricBatchSenderFactoryTest.java
@@ -9,18 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.http.HttpPoster;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MetricBatchSenderFactoryTest {
 
-  MetricBatchSenderFactory factory;
-
-  @BeforeEach
-  void setup() {
-    HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
-    factory = () -> httpPoster;
-  }
+  HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
+  MetricBatchSenderFactory factory = () -> httpPoster;
 
   @Test
   void testBuilders() {

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/SpanBatchSenderFactoryTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/SpanBatchSenderFactoryTest.java
@@ -9,18 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.http.HttpPoster;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SpanBatchSenderFactoryTest {
 
-  SpanBatchSenderFactory factory;
-
-  @BeforeEach
-  void setup() {
-    HttpPoster poster = (url, headers, body, mediaType) -> null;
-    factory = () -> poster;
-  }
+  HttpPoster httpPoster = (url, headers, body, mediaType) -> null;
+  SpanBatchSenderFactory factory = () -> httpPoster;
 
   @Test
   void testBuilders() {

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -1,6 +1,7 @@
 package com.newrelic.telemetry.events;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class EventBatchSenderTest {
 
@@ -76,12 +78,15 @@ public class EventBatchSenderTest {
     EventBatch batch = new EventBatch(events, new Attributes().put("f", "b"));
     Supplier<HttpPoster> posterSupplier = () -> poster;
 
-    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+    when(poster.post(eq(url), headersCaptor.capture(), isA(byte[].class), anyString()))
         .thenReturn(httpResponse);
 
     EventBatchSender logBatchSender = EventBatchSender.create(posterSupplier, baseConfig);
 
     Response result = logBatchSender.sendBatch(batch);
     assertEquals(expected, result);
+    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
+
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -86,7 +86,6 @@ public class EventBatchSenderTest {
 
     Response result = logBatchSender.sendBatch(batch);
     assertEquals(expected, result);
-    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
-
+    assertTrue(((String) headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -5,13 +5,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.BaseConfig;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.events.json.EventBatchMarshaller;
 import com.newrelic.telemetry.exceptions.RetryWithSplitException;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.http.HttpResponse;
 import com.newrelic.telemetry.transport.BatchDataSender;
+import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 public class EventBatchSenderTest {
@@ -47,5 +56,32 @@ public class EventBatchSenderTest {
     EventBatch batch = new EventBatch(Collections.emptyList(), new Attributes());
     Response response = testClass.sendBatch(batch);
     assertEquals(202, response.getStatusCode());
+  }
+
+  @Test
+  public void sendBatchViaCreate() throws Exception {
+    BaseConfig baseConfig = new BaseConfig("hi", true, "second");
+    Response expected = new Response(202, "okey", "bb");
+    HttpResponse httpResponse =
+        new HttpResponse(
+            expected.getBody(),
+            expected.getStatusCode(),
+            expected.getStatusMessage(),
+            new HashMap<>());
+    URL url = URI.create("https://trace-api.newrelic.com/v1/accounts/events").toURL();
+
+    HttpPoster poster = mock(HttpPoster.class);
+    Event event = new Event("mytype", new Attributes().put("a", "b"));
+    Collection<Event> events = Collections.singletonList(event);
+    EventBatch batch = new EventBatch(events, new Attributes().put("f", "b"));
+    Supplier<HttpPoster> posterSupplier = () -> poster;
+
+    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+        .thenReturn(httpResponse);
+
+    EventBatchSender logBatchSender = EventBatchSender.create(posterSupplier, baseConfig);
+
+    Response result = logBatchSender.sendBatch(batch);
+    assertEquals(expected, result);
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -5,6 +5,7 @@
 package com.newrelic.telemetry.logs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class LogBatchSenderTest {
 
@@ -66,13 +68,16 @@ class LogBatchSenderTest {
     LogBatch batch = new LogBatch(logs, new Attributes().put("f", "b"));
     Supplier<HttpPoster> posterSupplier = () -> poster;
 
-    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+    when(poster.post(eq(url), headersCaptor.capture(), isA(byte[].class), anyString()))
         .thenReturn(httpResponse);
 
     LogBatchSender logBatchSender = LogBatchSender.create(posterSupplier, baseConfig);
 
     Response result = logBatchSender.sendBatch(batch);
     assertEquals(expected, result);
+    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
+
   }
 
   @Test

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -76,8 +76,7 @@ class LogBatchSenderTest {
 
     Response result = logBatchSender.sendBatch(batch);
     assertEquals(expected, result);
-    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
-
+    assertTrue(((String) headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
   }
 
   @Test

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -5,14 +5,26 @@
 package com.newrelic.telemetry.logs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.BaseConfig;
 import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.http.HttpResponse;
 import com.newrelic.telemetry.logs.json.LogBatchMarshaller;
 import com.newrelic.telemetry.transport.BatchDataSender;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 class LogBatchSenderTest {
@@ -34,6 +46,33 @@ class LogBatchSenderTest {
 
     Response result = testClass.sendBatch(batch);
     assertEquals(response, result);
+  }
+
+  @Test
+  public void sendBatchViaCreate() throws Exception {
+    BaseConfig baseConfig = new BaseConfig("hi", true, "second");
+    Response expected = new Response(202, "okey", "bb");
+    HttpResponse httpResponse =
+        new HttpResponse(
+            expected.getBody(),
+            expected.getStatusCode(),
+            expected.getStatusMessage(),
+            new HashMap<>());
+    URL url = URI.create("https://log-api.newrelic.com/log/v1").toURL();
+
+    HttpPoster poster = mock(HttpPoster.class);
+    Log log = Log.builder().message("my log").build();
+    Collection<Log> logs = Collections.singletonList(log);
+    LogBatch batch = new LogBatch(logs, new Attributes().put("f", "b"));
+    Supplier<HttpPoster> posterSupplier = () -> poster;
+
+    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+        .thenReturn(httpResponse);
+
+    LogBatchSender logBatchSender = LogBatchSender.create(posterSupplier, baseConfig);
+
+    Response result = logBatchSender.sendBatch(batch);
+    assertEquals(expected, result);
   }
 
   @Test

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
@@ -85,7 +85,6 @@ class MetricBatchSenderTest {
 
     Response result = metricBatchSender.sendBatch(batch);
     assertEquals(expected, result);
-    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
-
+    assertTrue(((String) headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
@@ -5,6 +5,7 @@
 package com.newrelic.telemetry.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class MetricBatchSenderTest {
 
@@ -75,12 +77,15 @@ class MetricBatchSenderTest {
     MetricBatch batch = new MetricBatch(metrics, new Attributes().put("f", "b"));
     Supplier<HttpPoster> posterSupplier = () -> poster;
 
-    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+    when(poster.post(eq(url), headersCaptor.capture(), isA(byte[].class), anyString()))
         .thenReturn(httpResponse);
 
     MetricBatchSender metricBatchSender = MetricBatchSender.create(posterSupplier, baseConfig);
 
     Response result = metricBatchSender.sendBatch(batch);
     assertEquals(expected, result);
+    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
+
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
@@ -5,14 +5,26 @@
 package com.newrelic.telemetry.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.BaseConfig;
 import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.http.HttpResponse;
 import com.newrelic.telemetry.metrics.json.MetricBatchMarshaller;
 import com.newrelic.telemetry.transport.BatchDataSender;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 class MetricBatchSenderTest {
@@ -43,5 +55,32 @@ class MetricBatchSenderTest {
     MetricBatch batch = new MetricBatch(Collections.emptyList(), new Attributes());
     Response response = testClass.sendBatch(batch);
     assertEquals(202, response.getStatusCode());
+  }
+
+  @Test
+  public void sendBatchViaCreate() throws Exception {
+    BaseConfig baseConfig = new BaseConfig("hi", true, "second");
+    Response expected = new Response(202, "okey", "bb");
+    HttpResponse httpResponse =
+        new HttpResponse(
+            expected.getBody(),
+            expected.getStatusCode(),
+            expected.getStatusMessage(),
+            new HashMap<>());
+    URL url = URI.create("https://metric-api.newrelic.com/metric/v1").toURL();
+
+    HttpPoster poster = mock(HttpPoster.class);
+    Metric metric = new Gauge("foo", 12.1, 1234L, new Attributes().put("a", "b"));
+    Collection<Metric> metrics = Collections.singletonList(metric);
+    MetricBatch batch = new MetricBatch(metrics, new Attributes().put("f", "b"));
+    Supplier<HttpPoster> posterSupplier = () -> poster;
+
+    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+        .thenReturn(httpResponse);
+
+    MetricBatchSender metricBatchSender = MetricBatchSender.create(posterSupplier, baseConfig);
+
+    Response result = metricBatchSender.sendBatch(batch);
+    assertEquals(expected, result);
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
@@ -5,14 +5,26 @@
 package com.newrelic.telemetry.spans;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.BaseConfig;
 import com.newrelic.telemetry.Response;
+import com.newrelic.telemetry.http.HttpPoster;
+import com.newrelic.telemetry.http.HttpResponse;
 import com.newrelic.telemetry.spans.json.SpanBatchMarshaller;
 import com.newrelic.telemetry.transport.BatchDataSender;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 class SpanBatchSenderTest {
@@ -43,5 +55,32 @@ class SpanBatchSenderTest {
     SpanBatch batch = new SpanBatch(Collections.emptyList(), new Attributes());
     Response response = testClass.sendBatch(batch);
     assertEquals(202, response.getStatusCode());
+  }
+
+  @Test
+  public void sendBatchViaCreate() throws Exception {
+    BaseConfig baseConfig = new BaseConfig("hi", true, "second");
+    Response expected = new Response(202, "okey", "bb");
+    HttpResponse httpResponse =
+        new HttpResponse(
+            expected.getBody(),
+            expected.getStatusCode(),
+            expected.getStatusMessage(),
+            new HashMap<>());
+    URL url = URI.create("https://trace-api.newrelic.com/trace/v1").toURL();
+
+    HttpPoster poster = mock(HttpPoster.class);
+    Span span = Span.builder("oh").build();
+    Collection<Span> spans = Collections.singletonList(span);
+    SpanBatch batch = new SpanBatch(spans, new Attributes().put("f", "b"));
+    Supplier<HttpPoster> posterSupplier = () -> poster;
+
+    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+        .thenReturn(httpResponse);
+
+    SpanBatchSender spanBatchSender = SpanBatchSender.create(posterSupplier, baseConfig);
+
+    Response result = spanBatchSender.sendBatch(batch);
+    assertEquals(expected, result);
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
@@ -5,6 +5,7 @@
 package com.newrelic.telemetry.spans;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -26,6 +27,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.lang.model.util.Types;
 
 class SpanBatchSenderTest {
 
@@ -75,12 +79,14 @@ class SpanBatchSenderTest {
     SpanBatch batch = new SpanBatch(spans, new Attributes().put("f", "b"));
     Supplier<HttpPoster> posterSupplier = () -> poster;
 
-    when(poster.post(eq(url), isA(Map.class), isA(byte[].class), anyString()))
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+    when(poster.post(eq(url), headersCaptor.capture(), isA(byte[].class), anyString()))
         .thenReturn(httpResponse);
 
     SpanBatchSender spanBatchSender = SpanBatchSender.create(posterSupplier, baseConfig);
 
     Response result = spanBatchSender.sendBatch(batch);
     assertEquals(expected, result);
+    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
@@ -29,8 +29,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.lang.model.util.Types;
-
 class SpanBatchSenderTest {
 
   @Test
@@ -87,6 +85,6 @@ class SpanBatchSenderTest {
 
     Response result = spanBatchSender.sendBatch(batch);
     assertEquals(expected, result);
-    assertTrue(((String)headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
+    assertTrue(((String) headersCaptor.getValue().get("User-Agent")).endsWith(" second"));
   }
 }


### PR DESCRIPTION
This provides a `BaseConfig`, which can be an easy way to specify audit mode and secondary user agent for all components (senders) in the TelemetryClient.

This resolves #175 