### PR TITLE
Clean up endpoint override method

### DIFF
--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -69,7 +69,7 @@ class SpanApiIntegrationTest {
         factory
             .configureWith("fakeKey")
             .httpPoster(new OkHttpPoster(Duration.ofMillis(1500)))
-            .endpoint("http", containerIpAddress, SERVICE_PORT)
+            .endpoint(endpointUrl)
             .auditLoggingEnabled(true)
             .secondaryUserAgent("myTestApp")
             .build();

--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -15,6 +15,8 @@ import com.google.common.net.MediaType;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,10 +45,11 @@ class SpanApiIntegrationTest {
       new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
           .withExposedPorts(SERVICE_PORT);
+  private static URL endpointUrl;
   private SpanBatchSender spanBatchSender;
 
   @BeforeAll
-  static void beforeClass() {
+  static void beforeClass() throws MalformedURLException {
     container.setPortBindings(singletonList(SERVICE_PORT + ":1080"));
     container.setWaitStrategy(new WaitAllStrategy());
     container.setStartupCheckStrategy(
@@ -54,6 +57,7 @@ class SpanApiIntegrationTest {
     container.start();
     containerIpAddress = container.getContainerIpAddress();
     mockServerClient = new MockServerClient(containerIpAddress, SERVICE_PORT);
+    endpointUrl = new URL("http://" + containerIpAddress + ":" + SERVICE_PORT + "/trace/v1");
   }
 
   @BeforeEach

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -90,7 +90,7 @@ public class SenderConfiguration {
     /**
      * Configure the endpoint for data to be sent to. The default path will be used.
      *
-     * To be removed in 0.8.0
+     * <p>To be removed in 0.8.0
      *
      * @param scheme A valid URL scheme, such as "https"
      * @param host The host portion of the URL.
@@ -107,7 +107,7 @@ public class SenderConfiguration {
     /**
      * Configure the *full* endpoint URL for data to be sent to, including the path.
      *
-     * To be removed in 0.8.0
+     * <p>To be removed in 0.8.0
      *
      * @deprecated call the simpler endpoint() method instead
      * @param endpointUrl A full {@link URL}, including the path.
@@ -118,14 +118,14 @@ public class SenderConfiguration {
     }
 
     /**
-     * Configure the *full* endpoint URL for data to be sent to, including the path.
-     * You should only use this method if you wish to modify the default behavior,
-     * which is to send data to the Portland production US endpoints.
+     * Configure the *full* endpoint URL for data to be sent to, including the path. You should only
+     * use this method if you wish to modify the default behavior, which is to send data to the
+     * Portland production US endpoints.
      *
      * @param endpoint A full {@link URL}, including the path.
      * @return this builder.
      */
-    public SenderConfigurationBuilder endpoint(URL endpoint){
+    public SenderConfigurationBuilder endpoint(URL endpoint) {
       this.endpointUrl = endpoint;
       return this;
     }

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -88,28 +88,46 @@ public class SenderConfiguration {
     }
 
     /**
-     * Configure the *full* endpoint URL for data to be sent to, including the path.
-     *
-     * @param endpointUrl A full {@link URL}, including the path.
-     * @return this builder.
-     */
-    public SenderConfigurationBuilder endpointWithPath(URL endpointUrl) {
-      this.endpointUrl = endpointUrl;
-      return this;
-    }
-
-    /**
      * Configure the endpoint for data to be sent to. The default path will be used.
+     *
+     * To be removed in 0.8.0
      *
      * @param scheme A valid URL scheme, such as "https"
      * @param host The host portion of the URL.
      * @param port The port portion of the URL.
      * @return this builder.
      * @throws MalformedURLException If a valid URL cannot be constructed from the pieces provided.
+     * @deprecated call the simpler endpoint(URL) method with the full URL instead
      */
     public SenderConfigurationBuilder endpoint(String scheme, String host, int port)
         throws MalformedURLException {
       return endpointWithPath(new URL(scheme, host, port, basePath));
+    }
+
+    /**
+     * Configure the *full* endpoint URL for data to be sent to, including the path.
+     *
+     * To be removed in 0.8.0
+     *
+     * @deprecated call the simpler endpoint() method instead
+     * @param endpointUrl A full {@link URL}, including the path.
+     * @return this builder.
+     */
+    public SenderConfigurationBuilder endpointWithPath(URL endpointUrl) {
+      return endpoint(endpointUrl);
+    }
+
+    /**
+     * Configure the *full* endpoint URL for data to be sent to, including the path.
+     * You should only use this method if you wish to modify the default behavior,
+     * which is to send data to the Portland production US endpoints.
+     *
+     * @param endpoint A full {@link URL}, including the path.
+     * @return this builder.
+     */
+    public SenderConfigurationBuilder endpoint(URL endpoint){
+      this.endpointUrl = endpoint;
+      return this;
     }
 
     /**

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
@@ -90,7 +90,7 @@ public class ConfigurationExamples {
         EventBatchSender.create(
             EventBatchSenderFactory.fromHttpImplementation(Java11HttpPoster::new)
                 .configureWith(insightsInsertKey)
-                .endpointWithPath(new URL("http://special-events.com/my-endpoint-rocks/v1/api"))
+                .endpoint(new URL("http://special-events.com/my-endpoint-rocks/v1/api"))
                 .build());
 
     // Configure your log sender:

--- a/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
+++ b/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java
@@ -74,7 +74,7 @@ public class ConfigurationExamples {
                                 // configure custom stuff here, like proxies, etc.
                                 .build()))
                 .configureWith(insightsInsertKey)
-                .endpoint("http", "special-metrics.com", 80)
+                .endpoint(new URL("http://special-metrics.com/your/custom/path"))
                 .build());
 
     // Configure your span sender:
@@ -82,7 +82,7 @@ public class ConfigurationExamples {
         SpanBatchSender.create(
             SpanBatchSenderFactory.fromHttpImplementation(Java11HttpPoster::new)
                 .configureWith(insightsInsertKey)
-                .endpoint("https", "special-spans.com", 443)
+                .endpoint(new URL("https://special-spans.com/your/custom/path"))
                 .build());
 
     // Configure your event sender:


### PR DESCRIPTION
This resolves #196 

It also sets up the other `endpoint()` related methods (as described in #196) for deprecation in 0.8.0.