### PR TITLE
use new gradle syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Maven dependencies:
 Gradle dependencies: 
 
 ```
-api("com.newrelic.telemetry:telemetry:0.6.1")
+implementation("com.newrelic.telemetry:telemetry:0.6.1")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Maven dependencies:
 Gradle dependencies: 
 
 ```
-compile("com.newrelic.telemetry:telemetry:0.6.1")
-compile("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
+api("com.newrelic.telemetry:telemetry:0.6.1")
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
 ```
 
 Take a look at the example code in the [telemetry_examples](telemetry_examples) module. 


### PR DESCRIPTION
This resolves #199

I hope that `api()` is correct for telemetry while `implementation()` is correct for the okhttp lib support.  🤷 

Cribbed it from the OT exporter.