### PR TITLE
Update split for events

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -47,9 +47,7 @@ public class EventBatchSender {
    * @return The response from the ingest API.
    * @throws ResponseException In cases where the batch is unable to be successfully sent, one of
    *     the subclasses of {@link ResponseException} will be thrown. See the documentation on that
-   *     hierarchy for details on the recommended ways to respond to those exceptions. This method
-   *     will never throw RetryWithSplitException as it automatically handles splitting and retrying
-   *     outsize batches.
+   *     hierarchy for details on the recommended ways to respond to those exceptions.
    */
   public Response sendBatch(EventBatch batch) throws ResponseException {
     if (batch == null || batch.size() == 0) {
@@ -61,11 +59,7 @@ public class EventBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
 
-    try {
-      return sender.send(json);
-    } catch (RetryWithSplitException splitx) {
-      return splitBatchAndSend(batch, new LinkedBlockingDeque<>());
-    }
+    return sender.send(json);
   }
 
   @SuppressWarnings("unchecked")

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -10,20 +10,16 @@ import com.newrelic.telemetry.EventBatchSenderFactory;
 import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.SenderConfiguration.SenderConfigurationBuilder;
-import com.newrelic.telemetry.TelemetryBatch;
 import com.newrelic.telemetry.events.json.EventBatchMarshaller;
 import com.newrelic.telemetry.exceptions.ResponseException;
-import com.newrelic.telemetry.exceptions.RetryWithSplitException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
-import java.net.URL;
-import java.util.List;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.function.Supplier;
 
 public class EventBatchSender {
   private static final String EVENTS_PATH = "/v1/accounts/events";
@@ -60,42 +56,6 @@ public class EventBatchSender {
     String json = marshaller.toJson(batch);
 
     return sender.send(json);
-  }
-
-  @SuppressWarnings("unchecked")
-  Response splitBatchAndSend(EventBatch batch, BlockingDeque<TelemetryBatch> queue) {
-    logger.info(
-        "Tried to send a too-large event batch (number of events: {}) to the New Relic event ingest endpoint. Splitting)",
-        batch.size());
-    List<TelemetryBatch<Event>> twoBatches = batch.split();
-    Response response = null;
-
-    // Preserve in-order processing
-    queue.addFirst(twoBatches.get(1));
-    queue.addFirst(twoBatches.get(0));
-    while (!queue.isEmpty()) {
-      final EventBatch eb = (EventBatch) queue.pollFirst();
-      final String json = marshaller.toJson(eb);
-
-      try {
-        response = sender.send(json);
-      } catch (RetryWithSplitException splitx) {
-        response = splitBatchAndSend(eb, queue);
-      } catch (ResponseException rsx) {
-        // We have to log and swallow this exception as there may be other split batches
-        // might succeed at sending
-        logger.info(
-            "Failed to send a split event batch to the New Relic event ingest endpoint. Exception: {}",
-            rsx);
-      }
-    }
-    if (response == null) {
-      response =
-          new Response(
-              200, "OK", "Large payload was split - check log in case of dropped sub-batch");
-    }
-
-    return response;
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -15,11 +15,10 @@ import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URL;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EventBatchSender {
   private static final String EVENTS_PATH = "/v1/accounts/events";

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -48,9 +48,11 @@ public class EventBatchSenderTest {
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);
 
-    assertThrows(RetryWithSplitException.class, () -> {
-      testClass.sendBatch(batch);
-    });
+    assertThrows(
+        RetryWithSplitException.class,
+        () -> {
+          testClass.sendBatch(batch);
+        });
   }
 
   @Test

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -1,6 +1,7 @@
 package com.newrelic.telemetry.events;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -43,14 +44,13 @@ public class EventBatchSenderTest {
 
     Response ok = new Response(200, "OK", "yup");
     BatchDataSender sender = mock(BatchDataSender.class);
-    xxx
     when(sender.send(json)).thenThrow(RetryWithSplitException.class).thenReturn(ok);
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);
 
-    Response result = testClass.sendBatch(batch);
-    assertEquals(ok, result);
-    verify(sender, times(3)).send(any());
+    assertThrows(RetryWithSplitException.class, () -> {
+      testClass.sendBatch(batch);
+    });
   }
 
   @Test

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -43,6 +43,7 @@ public class EventBatchSenderTest {
 
     Response ok = new Response(200, "OK", "yup");
     BatchDataSender sender = mock(BatchDataSender.class);
+    xxx
     when(sender.send(json)).thenThrow(RetryWithSplitException.class).thenReturn(ok);
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);


### PR DESCRIPTION
This resolves #150 

Remove the handling of the specific retry inside the EventBatchSender and let it bubble up to the TelemetryClient where it can be retried consistently like the other telemetry types.