### PR TITLE
Upgrading okHTTP to 4.8.0

### DIFF
--- a/telemetry-http-okhttp/build.gradle.kts
+++ b/telemetry-http-okhttp/build.gradle.kts
@@ -1,5 +1,5 @@
 private object Versions {
-    const val okhttp = "3.14.1"
+    const val okhttp = "4.8.0"
     const val junit = "5.3.1"
     const val jsonassert = "1.5.0"
 }


### PR DESCRIPTION
Upgrading okHTTP to the latest (4.8.0) to work around an issue with cell load shifting in Infinite Tracing. [The upgrade guide](https://square.github.io/okhttp/upgrading_to_okhttp_4/) mentions that while it's now written in Kotlin, the API is stable fro 3.x -> 4.x.

