### PR TITLE
Build telemetry-all from sourceSets rather than project dependencies

### DIFF
--- a/telemetry-all/build.gradle.kts
+++ b/telemetry-all/build.gradle.kts
@@ -1,4 +1,6 @@
 private object Versions {
+        const val slf4j = "1.7.30"
+        const val gson = "2.8.6"
 }
 
 plugins {
@@ -11,10 +13,24 @@ configure<JavaPluginConvention> {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+sourceSets {
+    main {
+        java.setSrcDirs(listOf(
+                "src/main/java",
+                "../telemetry_core/src/main/java",
+                "../telemetry/src/main/java",
+                "../telemetry-http-java11/src/main/java"
+        ))
+        resources.setSrcDirs(listOf(
+                "../telemetry_core/src/main/resources",
+                "../telemetry/src/main/resources",
+                "../telemetry-http-java11/src/main/resources"
+        ))
+    }
+}
 dependencies {
-    "implementation"(project(":telemetry-core"))
-    "implementation"(project(":telemetry"))
-    "implementation"(project(":telemetry-http-java11"))
+    api("org.slf4j:slf4j-api:${Versions.slf4j}")
+    implementation("com.google.code.gson:gson:${Versions.gson}")
 }
 
 //plugins.withType<JavaPlugin>().configureEach {


### PR DESCRIPTION
Instead of trying to manipulate the various subproject JARs into
a single JAR that could be a module, this approach collects the
source directories from those subprojects and creates a special
source set within the project. in reality everything gets built again,
but now everything should be within a single toplevel package.