### PR TITLE
Add x-request-id header

### DIFF
--- a/integration_test/src/test/java/com/newrelic/telemetry/EventApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/EventApiIntegrationTest.java
@@ -89,8 +89,8 @@ class EventApiIntegrationTest {
   }
 
   @Test
-  @DisplayName("Low Level SDK can send a metric batch and returns a successful response")
-  void testSuccessfulMetricSend() throws Exception {
+  @DisplayName("Low Level SDK can send an event batch and returns a successful response")
+  void testSuccessfulEventBatchSend() throws Exception {
     List<Map<String, Object>> expectedPayload =
         Arrays.asList(
             ImmutableMap.<String, Object>builder()
@@ -108,6 +108,9 @@ class EventApiIntegrationTest {
                 .withBody(json)
                 .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* testApplication/1.0.0")
                 .withHeader("Content-Type", "application/json; charset=utf-8")
+                .withHeader(
+                    "X-Request-Id",
+                    "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
                 .withHeader("Content-Length", ".*"))
         .respond(new HttpResponse().withStatusCode(202));
 
@@ -124,8 +127,8 @@ class EventApiIntegrationTest {
   }
 
   @Test
-  @DisplayName("SDK responds with RetryWithBackoffException to MetricBatchSender timeout")
-  void testMetricBatchSenderTimeoutExceptionResponse() throws Exception {
+  @DisplayName("SDK responds with RetryWithBackoffException to EventBatchSender timeout")
+  void testEventBatchSenderTimeoutExceptionResponse() throws Exception {
     mockServerClient
         .when(
             new HttpRequest()
@@ -179,7 +182,7 @@ class EventApiIntegrationTest {
   @ParameterizedTest
   @MethodSource("codesAndExpectedExceptions")
   @DisplayName("SDK responds appropriately to non-202s by suggesting a course of action.")
-  void testMetricSendResponseCodes(
+  void testEventBatchSendResponseCodes(
       int statusCode, Class<? extends ResponseException> exceptionClass, String exceptionMessage)
       throws Exception {
     mockServerClient

--- a/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
@@ -99,6 +99,9 @@ class LogApiIntegrationTest {
                         new LogPayload[] {expectedPayload}, MediaType.JSON_UTF_8, MatchType.STRICT))
                 .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* myTestApp")
                 .withHeader("Content-Type", "application/json; charset=utf-8")
+                .withHeader(
+                    "X-Request-Id",
+                    "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
                 .withHeader("Content-Length", ".*"))
         .respond(new HttpResponse().withStatusCode(202));
 

--- a/integration_test/src/test/java/com/newrelic/telemetry/MetricApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/MetricApiIntegrationTest.java
@@ -132,6 +132,9 @@ class MetricApiIntegrationTest {
                         MatchType.STRICT))
                 .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* testApplication/1.0.0")
                 .withHeader("Content-Type", "application/json; charset=utf-8")
+                .withHeader(
+                    "X-Request-Id",
+                    "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
                 .withHeader("Content-Length", ".*"))
         .respond(new HttpResponse().withStatusCode(202));
 

--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -110,6 +110,9 @@ class SpanApiIntegrationTest {
                         MatchType.STRICT))
                 .withHeader("User-Agent", "NewRelic-Java-TelemetrySDK/.* myTestApp")
                 .withHeader("Content-Type", "application/json; charset=utf-8")
+                .withHeader(
+                    "X-Request-Id",
+                    "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
                 .withHeader("Content-Length", ".*"))
         .respond(new HttpResponse().withStatusCode(202));
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/TelemetryBatch.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/TelemetryBatch.java
@@ -73,7 +73,7 @@ public abstract class TelemetryBatch<T extends Telemetry> {
     return commonAttributes;
   }
 
-  public UUID getUuid(){
+  public UUID getUuid() {
     return uuid;
   }
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/TelemetryBatch.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/TelemetryBatch.java
@@ -11,10 +11,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /** Represents a collection of {@link Telemetry} instances and some common attributes */
 public abstract class TelemetryBatch<T extends Telemetry> {
 
+  private final UUID uuid = UUID.randomUUID();
   private Collection<T> telemetry;
 
   private Attributes commonAttributes;
@@ -69,6 +71,10 @@ public abstract class TelemetryBatch<T extends Telemetry> {
 
   public Attributes getCommonAttributes() {
     return commonAttributes;
+  }
+
+  public UUID getUuid(){
+    return uuid;
   }
 
   @Override

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -54,7 +54,7 @@ public class EventBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
 
-    return sender.send(json);
+    return sender.send(json, batch.getUuid());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -62,7 +62,7 @@ public class LogBatchSender {
         "Sending a log batch (number of logs: {}) to the New Relic log ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json);
+    return sender.send(json, batch.getUuid());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -70,7 +70,7 @@ public class MetricBatchSender {
         "Sending a metric batch (number of metrics: {}) to the New Relic metric ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json);
+    return sender.send(json, batch.getUuid());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -74,7 +74,7 @@ public class SpanBatchSender {
         "Sending a span batch (number of spans: {}) to the New Relic span ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json);
+    return sender.send(json, batch.getUuid());
   }
 
   /**

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -71,12 +71,6 @@ public class BatchDataSender {
     return BASE_USER_AGENT_VALUE + " " + additionalUserAgent;
   }
 
-  public Response send(String json)
-          throws DiscardBatchException, RetryWithSplitException, RetryWithBackoffException,
-          RetryWithRequestedWaitException {
-    return send(json, null);
-  }
-
   public Response send(String json, UUID batchId)
       throws DiscardBatchException, RetryWithSplitException, RetryWithBackoffException,
           RetryWithRequestedWaitException {

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -109,7 +109,7 @@ public class BatchDataSender {
     Map<String, String> headers = new HashMap<>();
     headers.put("Api-Key", apiKey);
     headers.put("Content-Encoding", "gzip");
-    if(requestId != null){
+    if (requestId != null) {
       headers.put("X-Request-Id", requestId.toString());
     }
     headers.put("User-Agent", userAgent);

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/transport/BatchDataSender.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import org.slf4j.Logger;
@@ -71,6 +72,12 @@ public class BatchDataSender {
   }
 
   public Response send(String json)
+          throws DiscardBatchException, RetryWithSplitException, RetryWithBackoffException,
+          RetryWithRequestedWaitException {
+    return send(json, null);
+  }
+
+  public Response send(String json, UUID batchId)
       throws DiscardBatchException, RetryWithSplitException, RetryWithBackoffException,
           RetryWithRequestedWaitException {
     if (auditLoggingEnabled) {
@@ -78,7 +85,7 @@ public class BatchDataSender {
     }
     byte[] payload = generatePayload(json);
 
-    return sendPayload(payload);
+    return sendPayload(payload, batchId);
   }
 
   private byte[] generatePayload(String json) throws DiscardBatchException {
@@ -102,12 +109,15 @@ public class BatchDataSender {
     return compressedOutput.toByteArray();
   }
 
-  private Response sendPayload(byte[] payload)
+  private Response sendPayload(byte[] payload, UUID requestId)
       throws DiscardBatchException, RetryWithSplitException, RetryWithBackoffException,
           RetryWithRequestedWaitException {
     Map<String, String> headers = new HashMap<>();
     headers.put("Api-Key", apiKey);
     headers.put("Content-Encoding", "gzip");
+    if(requestId != null){
+      headers.put("X-Request-Id", requestId.toString());
+    }
     headers.put("User-Agent", userAgent);
     try {
       HttpResponse response = client.post(endpointURl, headers, payload, MEDIA_TYPE);

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
@@ -5,7 +5,9 @@
 package com.newrelic.telemetry;
 
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.metrics.Count;
@@ -24,5 +26,20 @@ class TelemetryBatchTest {
         new MetricBatch(Collections.singleton(metric), new Attributes());
     assertTrue(batch1.isEmpty());
     assertFalse(batch2.isEmpty());
+  }
+
+  @Test
+  void testHasUUID() {
+    TelemetryBatch<Metric> batch1 = new MetricBatch(emptyList(), new Attributes());
+    TelemetryBatch<Metric> batch2 = new MetricBatch(emptyList(), new Attributes());
+    assertNotEquals(batch1.getUuid(), batch2.getUuid());
+  }
+
+  @Test
+  void testUuidFormat() {
+    TelemetryBatch<Metric> batch = new MetricBatch(emptyList(), new Attributes());
+    //2280a03c-9c2a-4527-ac32-1332e8de159c
+    String regex = "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$";
+    assertTrue(batch.getUuid().toString().matches(regex));
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
@@ -14,11 +14,9 @@ import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.MetricBatch;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 class TelemetryBatchTest {
@@ -43,7 +41,7 @@ class TelemetryBatchTest {
   @Test
   void testUuidFormat() {
     TelemetryBatch<Metric> batch = new MetricBatch(emptyList(), new Attributes());
-    //2280a03c-9c2a-4527-ac32-1332e8de159c
+    // 2280a03c-9c2a-4527-ac32-1332e8de159c
     String regex = "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$";
     assertTrue(batch.getUuid().toString().matches(regex));
   }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/TelemetryBatchTest.java
@@ -11,9 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.telemetry.metrics.Count;
+import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.MetricBatch;
+
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 class TelemetryBatchTest {
@@ -41,5 +46,18 @@ class TelemetryBatchTest {
     //2280a03c-9c2a-4527-ac32-1332e8de159c
     String regex = "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$";
     assertTrue(batch.getUuid().toString().matches(regex));
+  }
+
+  @Test
+  void testSplitMakesNewUuid() {
+    long now = System.currentTimeMillis();
+    Metric m1 = new Gauge("foo1", 12.34, now, new Attributes());
+    Metric m2 = new Gauge("foo2", 56.78, now, new Attributes());
+    TelemetryBatch<Metric> batch = new MetricBatch(Arrays.asList(m1, m2), new Attributes());
+    List<TelemetryBatch<Metric>> split = batch.split();
+    assertEquals(2, split.size());
+    assertNotEquals(batch.getUuid(), split.get(0).getUuid());
+    assertNotEquals(batch.getUuid(), split.get(1).getUuid());
+    assertNotEquals(split.get(0).getUuid(), split.get(1).getUuid());
   }
 }

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -44,7 +44,7 @@ public class EventBatchSenderTest {
 
     Response ok = new Response(200, "OK", "yup");
     BatchDataSender sender = mock(BatchDataSender.class);
-    when(sender.send(json)).thenThrow(RetryWithSplitException.class).thenReturn(ok);
+    when(sender.send(json, batch.getUuid())).thenThrow(RetryWithSplitException.class).thenReturn(ok);
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -44,7 +44,9 @@ public class EventBatchSenderTest {
 
     Response ok = new Response(200, "OK", "yup");
     BatchDataSender sender = mock(BatchDataSender.class);
-    when(sender.send(json, batch.getUuid())).thenThrow(RetryWithSplitException.class).thenReturn(ok);
+    when(sender.send(json, batch.getUuid()))
+        .thenThrow(RetryWithSplitException.class)
+        .thenReturn(ok);
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -42,7 +42,7 @@ class LogBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json)).thenReturn(response);
+    when(sender.send(json, batch.getUuid())).thenReturn(response);
 
     LogBatchSender testClass = new LogBatchSender(marshaller, sender);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
@@ -43,7 +43,7 @@ class MetricBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json)).thenReturn(response);
+    when(sender.send(json, batch.getUuid())).thenReturn(response);
 
     MetricBatchSender testClass = new MetricBatchSender(marshaller, sender);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
@@ -43,7 +43,7 @@ class SpanBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json)).thenReturn(response);
+    when(sender.send(json, batch.getUuid())).thenReturn(response);
 
     SpanBatchSender testClass = new SpanBatchSender(marshaller, sender);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
@@ -8,7 +8,6 @@ package com.newrelic.telemetry.transport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,7 +23,6 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 
 class BatchDataSenderTest {
@@ -37,10 +35,14 @@ class BatchDataSenderTest {
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(
-            "User-Agent", BatchDataSender.BASE_USER_AGENT_VALUE,
-            "Api-Key", "api-key",
-            "X-Request-Id", requestId.toString(),
-            "Content-Encoding", "gzip");
+            "User-Agent",
+            BatchDataSender.BASE_USER_AGENT_VALUE,
+            "Api-Key",
+            "api-key",
+            "X-Request-Id",
+            requestId.toString(),
+            "Content-Encoding",
+            "gzip");
     // note: not testing the gzipping here
     when(httpPoster.post(
             eq(endpointURl), eq(headers), any(), eq("application/json; charset=utf-8")))
@@ -60,10 +62,14 @@ class BatchDataSenderTest {
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(
-            "User-Agent", BatchDataSender.BASE_USER_AGENT_VALUE + " mySpecialUserAgent/1.0",
-            "Api-Key", "api-key",
-                "X-Request-Id", requestId.toString(),
-                "Content-Encoding", "gzip");
+            "User-Agent",
+            BatchDataSender.BASE_USER_AGENT_VALUE + " mySpecialUserAgent/1.0",
+            "Api-Key",
+            "api-key",
+            "X-Request-Id",
+            requestId.toString(),
+            "Content-Encoding",
+            "gzip");
     // note: not testing the gzipping here
     when(httpPoster.post(
             eq(endpointURl), eq(headers), any(), eq("application/json; charset=utf-8")))
@@ -83,10 +89,14 @@ class BatchDataSenderTest {
     HttpPoster httpPoster = mock(HttpPoster.class);
     Map<String, String> headers =
         ImmutableMap.of(
-            "User-Agent", BatchDataSender.BASE_USER_AGENT_VALUE,
-            "Api-Key", "api-key",
-              "X-Request-Id", requestId.toString(),
-              "Content-Encoding", "gzip");
+            "User-Agent",
+            BatchDataSender.BASE_USER_AGENT_VALUE,
+            "Api-Key",
+            "api-key",
+            "X-Request-Id",
+            requestId.toString(),
+            "Content-Encoding",
+            "gzip");
     // note: not testing the gzipping here
     when(httpPoster.post(
             eq(endpointURl), eq(headers), any(), eq("application/json; charset=utf-8")))


### PR DESCRIPTION
This resolves #200 

Note: In order to appear more consistent with the other headers, I left the casing mixed.  I assume that this is unimportant and that most frameworks will lowercase it anyway.  It just seemed too inconsistent to leave it lowercase here.