### PR TITLE
check executor is terminated. no stack trace

### DIFF
--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -167,10 +167,13 @@ public class TelemetryClient {
       long waitTime,
       TimeUnit timeUnit,
       Backoff backoff) {
+    if (executor.isTerminated()) {
+      return;
+    }
     try {
       executor.schedule(() -> sendWithErrorHandling(sender, batch, backoff), waitTime, timeUnit);
     } catch (RejectedExecutionException e) {
-      LOG.error("Problem scheduling batch.", e);
+      LOG.error("Problem scheduling batch.");
     }
   }
 

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -173,7 +173,7 @@ public class TelemetryClient {
     try {
       executor.schedule(() -> sendWithErrorHandling(sender, batch, backoff), waitTime, timeUnit);
     } catch (RejectedExecutionException e) {
-      LOG.error("Problem scheduling batch.");
+      LOG.error("Problem scheduling batch : " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
Retrying this https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/176 ...added a check to see if the executor is terminated.
No longer writes the stack trace to the log. Just adds a simple message that there was an issue scheduling the enqueued batch.