### PR TITLE
add empty and null guard for Event

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/Event.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/Event.java
@@ -24,6 +24,9 @@ public final class Event implements Telemetry {
    * @param attributes The key-value pairs that make up the event.
    */
   public Event(String eventType, Attributes attributes, long timestamp) {
+    if (eventType == null || "".equals(eventType)) {
+      throw new IllegalArgumentException("eventType must not be empty.");
+    }
     this.eventType = eventType;
     this.attributes = attributes;
     this.timestamp = timestamp;

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventTest.java
@@ -1,9 +1,9 @@
 package com.newrelic.telemetry.events;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.newrelic.telemetry.Attributes;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EventTest {
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventTest.java
@@ -1,0 +1,29 @@
+package com.newrelic.telemetry.events;
+
+import com.newrelic.telemetry.Attributes;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EventTest {
+
+  @Test
+  void testNullEventType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new Event(
+              new Event(null, new Attributes().put("key1", "val1"), System.currentTimeMillis()));
+        });
+  }
+
+  @Test
+  void testEmptyStringEventType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new Event(
+              new Event("", new Attributes().put("key2", "val2"), System.currentTimeMillis()));
+        });
+  }
+}


### PR DESCRIPTION
Grabbing this:
https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/195

Just adds a check on the first Event constructor that has eventType as a parameter which will always be called or will have already been called if creating from an Event.

