### PR TITLE
log metrics that are dropped

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricBatchJsonTelemetryBlockWriter.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/metrics/json/MetricBatchJsonTelemetryBlockWriter.java
@@ -9,7 +9,6 @@ import static java.lang.Double.isFinite;
 import com.newrelic.telemetry.metrics.*;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -49,18 +48,17 @@ public class MetricBatchJsonTelemetryBlockWriter {
   }
 
   private void logAllInvalid(Collection<Metric> metrics) {
-    metrics
-        .stream()
-        .filter(this::isInvalid)
-        .forEach(this::logInvalid);
+    metrics.stream().filter(this::isInvalid).forEach(this::logInvalid);
   }
 
   private void logInvalid(Metric invalidMetric) {
-    logger.debug("  * Dropped " +
-            typeDispatch(invalidMetric,
-                    count -> "Count(name=" + count.getName() + ",  value = " + count.getValue() + ")",
-                    gauge -> "Gauge(name=" + gauge.getName() + ", value = " + gauge.getValue() + ")",
-                    summary -> "Summary(name=" + summary.getName() + ", value = " + summary.getSum()));
+    logger.debug(
+        "  * Dropped "
+            + typeDispatch(
+                invalidMetric,
+                count -> "Count(name=" + count.getName() + ",  value = " + count.getValue() + ")",
+                gauge -> "Gauge(name=" + gauge.getName() + ", value = " + gauge.getValue() + ")",
+                summary -> "Summary(name=" + summary.getName() + ", value = " + summary.getSum()));
   }
 
   private boolean isInvalid(Metric metric) {

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/json/MetricBatchJsonTelemetryBlockWriterTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/json/MetricBatchJsonTelemetryBlockWriterTest.java
@@ -14,11 +14,9 @@ import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.MetricBatch;
 import com.newrelic.telemetry.metrics.json.MetricBatchJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.metrics.json.MetricToJson;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,15 +55,17 @@ class MetricBatchJsonTelemetryBlockWriterTest {
 
   @Test
   void testInvalidMetrics() {
-    Gauge invalidGauge1 = new Gauge("crumb", Float.NaN, System.currentTimeMillis(), new Attributes());
-    Gauge invalidGauge2 = new Gauge("crumb", Float.NEGATIVE_INFINITY, System.currentTimeMillis(), new Attributes());
+    Gauge invalidGauge1 =
+        new Gauge("crumb", Float.NaN, System.currentTimeMillis(), new Attributes());
+    Gauge invalidGauge2 =
+        new Gauge("crumb", Float.NEGATIVE_INFINITY, System.currentTimeMillis(), new Attributes());
     List<Metric> metrics = Arrays.asList(gauge, invalidGauge1, invalidGauge2);
     metricBatch = new MetricBatch(metrics, commonAttributes);
     when(metricToJson.writeGaugeJson(gauge)).thenReturn("valid one");
     when(metricToJson.writeGaugeJson(invalidGauge1)).thenReturn("SUPER DUPER INVALID");
     when(metricToJson.writeGaugeJson(invalidGauge2)).thenReturn("SUPER DUPER INVALID");
     MetricBatchJsonTelemetryBlockWriter testClass =
-            new MetricBatchJsonTelemetryBlockWriter(metricToJson);
+        new MetricBatchJsonTelemetryBlockWriter(metricToJson);
     StringBuilder builder = new StringBuilder();
     testClass.appendTelemetryJson(metricBatch, builder);
     assertEquals("\"metrics\":[valid one]", builder.toString());


### PR DESCRIPTION
(so that the user may debug/troubleshoot)

This resolves #158 .  Hopefully the debug level is ok.  I just worried about filling up log files on a busy system, but I'm not married to the solution.