### PR TITLE
Fix the default event endpoint to be the correct one.

### DIFF
--- a/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
@@ -206,7 +206,7 @@ class TelemetryClientTest {
     CountDownLatch latch = new CountDownLatch(1);
     Event event = new Event("flim", new Attributes().put("x", "y"));
     EventBatch metrics = new EventBatch(singletonList(event), new Attributes().put("a", "b"));
-    URL url = URI.create("https://trace-api.newrelic.com/v1/accounts/events").toURL();
+    URL url = URI.create("https://insights-collector.newrelic.com/v1/accounts/events").toURL();
 
     TelemetryClient client = TelemetryClient.create(posterSupplier, baseConfig);
 

--- a/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 public class EventBatchSender {
   private static final String EVENTS_PATH = "/v1/accounts/events";
-  private static final String DEFAULT_URL = "https://trace-api.newrelic.com/";
+  private static final String DEFAULT_URL = "https://insights-collector.newrelic.com/";
 
   private static final Logger logger = LoggerFactory.getLogger(EventBatchSender.class);
 

--- a/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry_core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -75,7 +75,7 @@ public class EventBatchSenderTest {
             expected.getStatusCode(),
             expected.getStatusMessage(),
             new HashMap<>());
-    URL url = URI.create("https://trace-api.newrelic.com/v1/accounts/events").toURL();
+    URL url = URI.create("https://insights-collector.newrelic.com/v1/accounts/events").toURL();
 
     HttpPoster poster = mock(HttpPoster.class);
     Event event = new Event("mytype", new Attributes().put("a", "b"));


### PR DESCRIPTION
This fixes #224 

Change the default event endpoint to be the right one, which is https://insights-collector.newrelic.com/v1/accounts/events