### PR TITLE
add deprecated annotation

### DIFF
--- a/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry_core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -95,6 +95,7 @@ public class SenderConfiguration {
      * @throws MalformedURLException If a valid URL cannot be constructed from the pieces provided.
      * @deprecated call the simpler endpoint(URL) method with the full URL instead
      */
+    @Deprecated
     public SenderConfigurationBuilder endpoint(String scheme, String host, int port)
         throws MalformedURLException {
       return endpointWithPath(new URL(scheme, host, port, basePath));
@@ -109,6 +110,7 @@ public class SenderConfiguration {
      * @param endpointUrl A full {@link URL}, including the path.
      * @return this builder.
      */
+    @Deprecated
     public SenderConfigurationBuilder endpointWithPath(URL endpointUrl) {
       return endpoint(endpointUrl);
     }


### PR DESCRIPTION
now we have only these messages:
```
newrelic-telemetry-sdk-java# ./gradlew clean build -x integration_test:test -x test

> Task :telemetry-http-okhttp:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :telemetry_examples:compileJava
Note: /dev_uai/newrelic-telemetry-sdk-java/telemetry_examples/src/main/java/com/newrelic/telemetry/examples/ConfigurationExamples.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings
```