### PR TITLE
Update versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 
 # Here is where we manage the version
 group=com.newrelic.telemetry
-version=0.8.2-SNAPSHOT
+version=0.9.0
 
 # Set this to true to enable using a local sonatype (for debugging publishing issues)
 # Start a local sonatype in docker with this command:
@@ -29,4 +29,4 @@ jsonassertVersion=1.5.0
 mockitoVersion=2.23.0
 mockserverVersion=5.5.1
 okhttpVersion=4.8.0
-testContainerVersion=1.11.3
+testContainerVersion=1.15.0-rc2

--- a/telemetry/build.gradle.kts
+++ b/telemetry/build.gradle.kts
@@ -8,7 +8,7 @@ configure<JavaPluginConvention> {
 }
 
 dependencies {
-    "api"(project(":telemetry-core"))
+    api(project(":telemetry-core"))
 
     testImplementation("org.slf4j:slf4j-simple:${slf4jVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")


### PR DESCRIPTION
We decided not to do a patch release after all, so let's go right to `0.9.0`.

This also [works around a problem](https://github.com/testcontainers/testcontainers-java/issues/3166) with testcontainers on docker on osx.