### PR TITLE
Add module-info for telemetry-all

### DIFF
--- a/telemetry-all/src/main/java/module-info.java
+++ b/telemetry-all/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module com.newrelic.telemetry {
+  exports com.newrelic.telemetry;
+  exports com.newrelic.telemetry.metrics;
+  exports com.newrelic.telemetry.events;
+  exports com.newrelic.telemetry.http;
+
+  requires java.net.http;
+  requires com.google.gson;
+  requires org.slf4j;
+}


### PR DESCRIPTION
The module-info file seem to have gone AWOL in the previous. This PR adds it, so that telemetry-all can be a proper modular artifact.