### PR TITLE
Log batch type

### DIFF
--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -55,7 +55,7 @@ public class EventBatchSender {
         batch.size());
     String json = marshaller.toJson(batch);
 
-    return sender.send(json, batch.getUuid());
+    return sender.send(json, batch);
   }
 
   /**

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -62,7 +62,7 @@ public class LogBatchSender {
         "Sending a log batch (number of logs: {}) to the New Relic log ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json, batch.getUuid());
+    return sender.send(json, batch);
   }
 
   /**

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -58,7 +58,7 @@ public class MetricBatchSender {
         "Sending a metric batch (number of metrics: {}) to the New Relic metric ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json, batch.getUuid());
+    return sender.send(json, batch);
   }
 
   /**

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -62,7 +62,7 @@ public class SpanBatchSender {
         "Sending a span batch (number of spans: {}) to the New Relic span ingest endpoint)",
         batch.size());
     String json = marshaller.toJson(batch);
-    return sender.send(json, batch.getUuid());
+    return sender.send(json, batch);
   }
 
   /**

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/events/EventBatchSenderTest.java
@@ -4,7 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.BaseConfig;
@@ -44,9 +48,7 @@ public class EventBatchSenderTest {
 
     Response ok = new Response(200, "OK", "yup");
     BatchDataSender sender = mock(BatchDataSender.class);
-    when(sender.send(json, batch.getUuid()))
-        .thenThrow(RetryWithSplitException.class)
-        .thenReturn(ok);
+    when(sender.send(json, batch)).thenThrow(RetryWithSplitException.class).thenReturn(ok);
 
     EventBatchSender testClass = new EventBatchSender(marshaller, sender);
 

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/logs/LogBatchSenderTest.java
@@ -42,7 +42,7 @@ class LogBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json, batch.getUuid())).thenReturn(response);
+    when(sender.send(json, batch)).thenReturn(response);
 
     LogBatchSender testClass = new LogBatchSender(marshaller, sender);
 

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/metrics/MetricBatchSenderTest.java
@@ -43,7 +43,7 @@ class MetricBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json, batch.getUuid())).thenReturn(response);
+    when(sender.send(json, batch)).thenReturn(response);
 
     MetricBatchSender testClass = new MetricBatchSender(marshaller, sender);
 

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/spans/SpanBatchSenderTest.java
@@ -43,7 +43,7 @@ class SpanBatchSenderTest {
     BatchDataSender sender = mock(BatchDataSender.class);
 
     when(marshaller.toJson(batch)).thenReturn(json);
-    when(sender.send(json, batch.getUuid())).thenReturn(response);
+    when(sender.send(json, batch)).thenReturn(response);
 
     SpanBatchSender testClass = new SpanBatchSender(marshaller, sender);
 

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/transport/BatchDataSenderTest.java
@@ -18,16 +18,25 @@ import com.newrelic.telemetry.Response;
 import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.http.HttpResponse;
+import com.newrelic.telemetry.metrics.MetricBatch;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BatchDataSenderTest {
 
   private final UUID requestId = UUID.fromString("abc-123-def-dead-beef");
+  private MetricBatch batch;
+
+  @BeforeEach
+  void setup() {
+    batch = mock(MetricBatch.class);
+    when(batch.getUuid()).thenReturn(requestId);
+  }
 
   @Test
   void testSend_noSecondaryUserAgent() throws Exception {
@@ -51,8 +60,7 @@ class BatchDataSenderTest {
     BatchDataSender testClass =
         new BatchDataSender(httpPoster, "api-key", endpointURl, false, null);
 
-    Response response = testClass.send("{}", requestId);
-
+    Response response = testClass.send("{}", batch);
     assertEquals(new Response(202, "OK", "yepyep"), response);
   }
 
@@ -78,7 +86,7 @@ class BatchDataSenderTest {
     BatchDataSender testClass =
         new BatchDataSender(httpPoster, "api-key", endpointURl, false, "mySpecialUserAgent/1.0");
 
-    Response response = testClass.send("{}", requestId);
+    Response response = testClass.send("{}", batch);
 
     assertEquals(new Response(202, "OK", "yepyep"), response);
   }
@@ -108,7 +116,7 @@ class BatchDataSenderTest {
     RetryWithBackoffException exception =
         assertThrows(
             RetryWithBackoffException.class,
-            () -> testClass.send("{}", requestId),
+            () -> testClass.send("{}", batch),
             "Should have thrown a retry with backoff");
 
     assertNotNull(exception.getCause());

--- a/telemetry/src/main/java/com/newrelic/telemetry/LoggingNotificationHandler.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/LoggingNotificationHandler.java
@@ -19,11 +19,18 @@ public class LoggingNotificationHandler implements NotificationHandler {
   @Override
   public void noticeInfo(
       String message, Exception exception, TelemetryBatch<? extends Telemetry> batch) {
-    logger.info(message, exception);
+    logger.info(addBatchType(message, batch), exception);
   }
 
   @Override
   public void noticeError(String message, Throwable t, TelemetryBatch<? extends Telemetry> batch) {
-    logger.error(message, t);
+    logger.error(addBatchType(message, batch), t);
+  }
+
+  private String addBatchType(String message, TelemetryBatch<? extends Telemetry> batch) {
+    if (batch != null) {
+      return String.format("[%s] - %s", batch.getClass().getSimpleName(), message);
+    }
+    return message;
   }
 }

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -232,11 +232,7 @@ public class TelemetryClient {
   private <T extends Telemetry> void splitAndSend(
       BatchSender sender, TelemetryBatch<T> batch, RetryWithSplitException e) {
     if (notificationHandler != null) {
-      notificationHandler.noticeInfo(
-          String.format(
-              "%s size too large, splitting and retrying.", batch.getClass().getSimpleName()),
-          e,
-          batch);
+      notificationHandler.noticeInfo("Batch size too large, splitting and retrying.", e, batch);
     }
     List<TelemetryBatch<T>> splitBatches = batch.split();
     splitBatches.forEach(
@@ -250,8 +246,8 @@ public class TelemetryClient {
     if (notificationHandler != null) {
       notificationHandler.noticeInfo(
           String.format(
-              "%s sending failed. Retrying failed batch after %d %s",
-              batch.getClass().getSimpleName(), e.getWaitTime(), e.getTimeUnit()),
+              "Batch sending failed. Retrying failed batch after %d %s",
+              e.getWaitTime(), e.getTimeUnit()),
           batch);
     }
     scheduleBatchSend(sender, batch, e.getWaitTime(), e.getTimeUnit());

--- a/telemetry/src/test/java/com/newrelic/telemetry/LimitingSchedulerTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/LimitingSchedulerTest.java
@@ -58,7 +58,14 @@ class LimitingSchedulerTest {
     assertFalse(result2);
     assertTrue(latch.await(5, SECONDS));
     assertEquals(new HashSet<>(Collections.singletonList("1")), seen.keySet());
-    boolean result3 = testClass.schedule(6, () -> {}, 13, TimeUnit.MILLISECONDS);
+    boolean result3 = false;
+    for (int i = 0; i < 10; i++) {
+      result3 = testClass.schedule(6, () -> {}, 13, TimeUnit.MILLISECONDS);
+      if (result3) {
+        break;
+      }
+      Thread.sleep(1000);
+    }
     assertTrue(result3);
   }
 

--- a/telemetry/src/test/java/com/newrelic/telemetry/NotificationHandlerTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/NotificationHandlerTest.java
@@ -1,5 +1,10 @@
 package com.newrelic.telemetry;
 
+import com.newrelic.telemetry.metrics.Gauge;
+import com.newrelic.telemetry.metrics.Metric;
+import com.newrelic.telemetry.metrics.MetricBatch;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -16,5 +21,21 @@ public class NotificationHandlerTest {
 
     notificationHandler.noticeInfo("A message", null);
     Mockito.verify(log).info("A message", (Throwable) null);
+  }
+
+  @Test
+  void shouldAddMetricBatchTypeToMessage() {
+    Logger log = Mockito.mock(Logger.class);
+    Attributes attributes = new Attributes();
+    Collection<Metric> metrics = Arrays.asList(new Gauge("Nicholas Gauge", 4.0, 45L, attributes));
+    MetricBatch batch = new MetricBatch(metrics, attributes);
+    NotificationHandler notificationHandler = new LoggingNotificationHandler(log);
+    RuntimeException e = new RuntimeException("oops");
+
+    notificationHandler.noticeError("An Error", e, batch);
+    Mockito.verify(log).error("[MetricBatch] - An Error", e);
+
+    notificationHandler.noticeInfo("A message", batch);
+    Mockito.verify(log).info("[MetricBatch] - A message", (Throwable) null);
   }
 }

--- a/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
@@ -166,7 +166,7 @@ class TelemetryClientTest {
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
         Collections.singletonList(
-            "MetricBatch sending failed. Retrying failed batch after 15 MILLISECONDS"),
+            "Batch sending failed. Retrying failed batch after 15 MILLISECONDS"),
         customNotificationHandler.infoMessages);
   }
 
@@ -209,7 +209,7 @@ class TelemetryClientTest {
     assertTrue(result);
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
+        Collections.singletonList("Batch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 
@@ -251,7 +251,7 @@ class TelemetryClientTest {
     assertEquals(0, customNotificationHandler.errorMessages.size());
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
+        Collections.singletonList("Batch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 
@@ -297,7 +297,7 @@ class TelemetryClientTest {
     assertTrue(batch2Seen.get());
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
+        Collections.singletonList("Batch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 

--- a/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
+++ b/telemetry/src/test/java/com/newrelic/telemetry/TelemetryClientTest.java
@@ -166,7 +166,7 @@ class TelemetryClientTest {
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
         Collections.singletonList(
-            "Metric batch sending failed. Retrying failed batch after 15 MILLISECONDS"),
+            "MetricBatch sending failed. Retrying failed batch after 15 MILLISECONDS"),
         customNotificationHandler.infoMessages);
   }
 
@@ -209,7 +209,7 @@ class TelemetryClientTest {
     assertTrue(result);
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("Metric batch size too large, splitting and retrying."),
+        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 
@@ -251,7 +251,7 @@ class TelemetryClientTest {
     assertEquals(0, customNotificationHandler.errorMessages.size());
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("Metric batch size too large, splitting and retrying."),
+        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 
@@ -297,7 +297,7 @@ class TelemetryClientTest {
     assertTrue(batch2Seen.get());
     assertEquals(Collections.emptyList(), customNotificationHandler.errorMessages);
     assertEquals(
-        Collections.singletonList("Metric batch size too large, splitting and retrying."),
+        Collections.singletonList("MetricBatch size too large, splitting and retrying."),
         customNotificationHandler.infoMessages);
   }
 


### PR DESCRIPTION
This resolves #238 

Get batch type from `batch.getClass().getSimpleName()` and apply to all relevant log messages. 

Manual testing output

```
[Thread-0] DEBUG com.newrelic.telemetry.spans.SpanBatchSender - Sending a span batch (number of spans: 1) to the New Relic span ingest endpoint)
[Thread-0] DEBUG com.newrelic.telemetry.spans.json.SpanBatchMarshaller - Generating json for span batch.
[main] DEBUG com.newrelic.telemetry.metrics.MetricBuffer - Creating metric batch.
[main] INFO com.newrelic.telemetry.TelemetryClient - Shutting down the TelemetryClient background Executor
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json for SpanBatch : [{"common":{"trace.id":"cbc8fcc5-6826-4961-88b3-b4a646cf7283","attributes":{"environment":"staging","service.name":"TelemetryClientExampleService","exampleName":"TelemetryClientExample","host.hostname":"C02WC0RNHTD8","instrumentation.provider":"Manual instrumentation"}},"spans":[{"id":"b77ba918-9443-43e5-a068-bd1cb8153328","trace.id":"902ceab8-6029-42b9-9eb5-11e1dd5314d0","timestamp":1607214596526,"attributes":{"duration.ms":150.0,"name":"testSpan"}}]}] 
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API for SpanBatch: code: 202, body: {"requestId":"87b33e93-0001-b000-0000-0176357483f4"}
[Thread-0] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry - SpanBatch - sent
[Thread-0] DEBUG com.newrelic.telemetry.metrics.MetricBatchSender - Sending a metric batch (number of metrics: 5) to the New Relic metric ingest endpoint)
[Thread-0] DEBUG com.newrelic.telemetry.metrics.json.MetricBatchMarshaller - Generating json for metric batch.
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json for MetricBatch : [{"common":{"attributes":{"environment":"staging","service.name":"TelemetryClientExampleService","exampleName":"TelemetryClientExample","host.hostname":"C02WC0RNHTD8","instrumentation.provider":"Manual instrumentation"}},"metrics":[{"name":"temperatureC","type":"gauge","value":44.0,"timestamp":1607214596530,"attributes":{"room":"kitchen"}},{"name":"temperatureC","type":"gauge","value":25.0,"timestamp":1607214596530,"attributes":{"room":"bathroom"}},{"name":"temperatureC","type":"gauge","value":10.0,"timestamp":1607214596530,"attributes":{"room":"basement"}},{"name":"bugsSquashed","type":"count","value":5.0,"timestamp":1607214596530,"interval.ms":3,"attributes":{"project":"JAVA"}},{"name":"throughput","type":"summary","value":{"count":25,"sum":100.0,"min":1.0,"max":10.0},"timestamp":1607214596530,"interval.ms":3,"attributes":{}}]}] 
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API for MetricBatch: code: 202, body: {"requestId":"41b19674-0024-b000-0000-0176357484d7"}
[Thread-0] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry - MetricBatch - sent
[Thread-0] DEBUG com.newrelic.telemetry.events.EventBatchSender - Sending an event batch (number of events: 1) to the New Relic event ingest endpoint)
[Thread-0] DEBUG com.newrelic.telemetry.events.json.EventBatchMarshaller - Generating json for event batch.
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json for EventBatch : [{"eventType":"TestEvent","timestamp":1607214596535,"environment":"staging","service.name":"TelemetryClientExampleService","exampleName":"TelemetryClientExample","testKey":"testValue","host.hostname":"C02WC0RNHTD8","instrumentation.provider":"Manual instrumentation"}] 
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API for EventBatch: code: 200, body: {"success":true, "uuid":"ce270cfa-0021-b000-0000-0176357485a8"}
[Thread-0] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry - EventBatch - sent
[Thread-0] DEBUG com.newrelic.telemetry.logs.LogBatchSender - Sending a log batch (number of logs: 1) to the New Relic log ingest endpoint)
[Thread-0] DEBUG com.newrelic.telemetry.logs.json.LogBatchMarshaller - Generating json for log batch.
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json for LogBatch : [{"common":{"attributes":{"environment":"staging","service.name":"TelemetryClientExampleService","exampleName":"TelemetryClientExample","host.hostname":"C02WC0RNHTD8","instrumentation.provider":"Manual instrumentation"}},"logs":[{"timestamp":1607214596536,"attributes":{"trace.id":"902ceab8-6029-42b9-9eb5-11e1dd5314d0","log.level":"INFO","span.id":"b77ba918-9443-43e5-a068-bd1cb8153328"},"message":"Logging a message here about a span."}]}] 
[Thread-0] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API for LogBatch: code: 202, body: {"requestId":"de04effa-0021-b000-0000-01763574867d"}
[Thread-0] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry - LogBatch - sent
```
