### PR TITLE
ensure dependency module-info.class dont make it into telemetry-core …

### DIFF
--- a/telemetry-core/build.gradle.kts
+++ b/telemetry-core/build.gradle.kts
@@ -58,6 +58,8 @@ tasks {
         manifest {
             attributes(mapOf("Implementation-Version" to project.version, "Implementation-Vendor" to "New Relic, Inc."))
         }
+        // Ensure module-info.class files from dependencies don't erroneously make it into the jar
+        exclude("**/module-info.class")
         relocate("com.google.gson", "com.newrelic.relocated")
         minimize()
     }


### PR DESCRIPTION
Breaking out part of this larger [PR](https://github.com/newrelic/newrelic-telemetry-sdk-java/pull/267) that fixes the `telemetry-core` shadowJar, which was erroneously including the `module-info.class` file from its `com.google.gson` dependency.