### PR TITLE
Added EU endpoint support and Unit tests in SenderConfiguration and the BatchSenders for all data types.

### DIFF
--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -129,8 +129,8 @@ public class SenderConfiguration {
 
     /**
      * Configure the *full* endpoint URL for data to be sent to, including the path. You should only
-     * use this method if you wish to send data to endpoints other than the US and EU production endpoints.
-     *
+     * use this method if you wish to send data to endpoints other than the US and EU production
+     * endpoints.
      *
      * @param endpoint A full {@link URL}, including the path.
      * @return this builder.

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -13,12 +13,13 @@ import java.net.URL;
 
 /** Configuration options for the various classes that send data to the New Relic ingest APIs. */
 public class SenderConfiguration {
+  private static final String DEFAULT_US_REGION = "US";
+
   private final BaseConfig baseConfig;
   private final HttpPoster httpPoster;
   private final URL endpointUrl;
   private final boolean useLicenseKey;
-
-  public static String endpointRegion = "US";
+  private final String endpointRegion;
 
   public SenderConfiguration(
       String apiKey,
@@ -26,7 +27,14 @@ public class SenderConfiguration {
       URL endpointUrl,
       boolean auditLoggingEnabled,
       String secondaryUserAgent) {
-    this(apiKey, httpPoster, endpointUrl, auditLoggingEnabled, secondaryUserAgent, false);
+    this(
+        apiKey,
+        httpPoster,
+        endpointUrl,
+        auditLoggingEnabled,
+        secondaryUserAgent,
+        false,
+        DEFAULT_US_REGION);
   }
 
   public SenderConfiguration(
@@ -35,11 +43,13 @@ public class SenderConfiguration {
       URL endpointUrl,
       boolean auditLoggingEnabled,
       String secondaryUserAgent,
-      boolean useLicenseKey) {
+      boolean useLicenseKey,
+      String endpointRegion) {
     this.httpPoster = httpPoster;
     this.endpointUrl = endpointUrl;
     this.baseConfig = new BaseConfig(apiKey, auditLoggingEnabled, secondaryUserAgent);
     this.useLicenseKey = useLicenseKey;
+    this.endpointRegion = endpointRegion;
   }
 
   public String getApiKey() {
@@ -84,6 +94,7 @@ public class SenderConfiguration {
     private URL endpointUrl;
     private boolean auditLoggingEnabled = false;
     private boolean useLicenseKey = false;
+    private String endpointRegion = DEFAULT_US_REGION;
     private String secondaryUserAgent;
 
     public SenderConfigurationBuilder(String defaultUrl, String basePath) {
@@ -138,12 +149,17 @@ public class SenderConfiguration {
      * Sets the region so that it is used in the individual batch senders (e.x. MetricBatchSender,
      * LogBatchSender, SpanBatchSenders) to configure regional endpoints and send data to New Relic
      *
-     * @param region String to indicate whether the account is in an American (US) or European (EU)
-     *     region
+     * @param region String to indicate whether the account is in an American or European region. US
+     *     --> American Region and EU --> European Region
      * @return this builder
      */
-    public SenderConfigurationBuilder setRegion(String region) {
-      SenderConfiguration.endpointRegion = region.toUpperCase();
+    public SenderConfigurationBuilder setRegion(String region) throws IllegalArgumentException {
+      // Add IllegalArgumentException if region isn't US or EU
+      region = region.toUpperCase();
+      if (!region.equals("US") && !region.equals("EU")) {
+        throw new IllegalArgumentException("The only supported regions are the US and EU regions");
+      }
+      this.endpointRegion = region;
       return this;
     }
 
@@ -179,7 +195,8 @@ public class SenderConfiguration {
           getOrDefaultSendUrl(),
           auditLoggingEnabled,
           secondaryUserAgent,
-          useLicenseKey);
+          useLicenseKey,
+          endpointRegion);
     }
 
     private URL getOrDefaultSendUrl() {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -18,6 +18,9 @@ public class SenderConfiguration {
   private final URL endpointUrl;
   private final boolean useLicenseKey;
 
+  public static String endpointRegion = "US";
+
+
   public SenderConfiguration(
       String apiKey,
       HttpPoster httpPoster,
@@ -63,6 +66,9 @@ public class SenderConfiguration {
   public boolean useLicenseKey() {
     return useLicenseKey;
   }
+
+  public String getRegion() { return endpointRegion; }
+
 
   public static SenderConfigurationBuilder builder(String defaultUrl, String basePath) {
     return new SenderConfigurationBuilder(defaultUrl, basePath);
@@ -125,6 +131,20 @@ public class SenderConfiguration {
      */
     public SenderConfigurationBuilder useLicenseKey(boolean useLicenseKey) {
       this.useLicenseKey = useLicenseKey;
+      return this;
+    }
+
+    /**
+     * Sets the region so that it is used in the individual batch senders (e.x. MetricBatchSender,
+     * LogBatchSender, SpanBatchSenders) to configure regional endpoints and send data to New Relic
+     *
+     * @param region String to indicate whether the account is in an American (US) or European (EU) region
+     * @return this builder
+     *
+     */
+
+    public SenderConfigurationBuilder setRegion(String region) {
+      SenderConfiguration.endpointRegion = region.toUpperCase();
       return this;
     }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -156,7 +156,7 @@ public class SenderConfiguration {
      * LogBatchSender, SpanBatchSenders) to configure regional endpoints and send data to New Relic
      *
      * @param region String to indicate whether the account is in an American or European region. US
-     *     --> American Region and EU --> European Region
+     *     (for American Region), EU (for European Region)
      * @return this builder
      */
     public SenderConfigurationBuilder setRegion(String region) throws IllegalArgumentException {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -20,7 +20,6 @@ public class SenderConfiguration {
 
   public static String endpointRegion = "US";
 
-
   public SenderConfiguration(
       String apiKey,
       HttpPoster httpPoster,
@@ -67,8 +66,9 @@ public class SenderConfiguration {
     return useLicenseKey;
   }
 
-  public String getRegion() { return endpointRegion; }
-
+  public String getRegion() {
+    return endpointRegion;
+  }
 
   public static SenderConfigurationBuilder builder(String defaultUrl, String basePath) {
     return new SenderConfigurationBuilder(defaultUrl, basePath);
@@ -138,11 +138,10 @@ public class SenderConfiguration {
      * Sets the region so that it is used in the individual batch senders (e.x. MetricBatchSender,
      * LogBatchSender, SpanBatchSenders) to configure regional endpoints and send data to New Relic
      *
-     * @param region String to indicate whether the account is in an American (US) or European (EU) region
+     * @param region String to indicate whether the account is in an American (US) or European (EU)
+     *     region
      * @return this builder
-     *
      */
-
     public SenderConfigurationBuilder setRegion(String region) {
       SenderConfiguration.endpointRegion = region.toUpperCase();
       return this;

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -14,7 +14,6 @@ import java.net.URL;
 /** Configuration options for the various classes that send data to the New Relic ingest APIs. */
 public class SenderConfiguration {
   private static final String DEFAULT_US_REGION = "US";
-  private static boolean userProvidedEndpoint = false;
 
   private final BaseConfig baseConfig;
   private final HttpPoster httpPoster;
@@ -81,10 +80,6 @@ public class SenderConfiguration {
     return endpointRegion;
   }
 
-  public boolean isUserProvideEndpoint() {
-    return userProvidedEndpoint;
-  }
-
   public static SenderConfigurationBuilder builder(String defaultUrl, String basePath) {
     return new SenderConfigurationBuilder(defaultUrl, basePath);
   }
@@ -136,7 +131,6 @@ public class SenderConfiguration {
      * @return this builder.
      */
     public SenderConfigurationBuilder endpoint(URL endpoint) {
-      SenderConfiguration.userProvidedEndpoint = true;
       this.endpointUrl = endpoint;
       return this;
     }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -154,7 +154,7 @@ public class SenderConfiguration {
      * @return this builder
      */
     public SenderConfigurationBuilder setRegion(String region) throws IllegalArgumentException {
-      // Add IllegalArgumentException if region isn't US or EU
+
       region = region.toUpperCase();
       if (!region.equals("US") && !region.equals("EU")) {
         throw new IllegalArgumentException("The only supported regions are the US and EU regions");

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/SenderConfiguration.java
@@ -14,6 +14,7 @@ import java.net.URL;
 /** Configuration options for the various classes that send data to the New Relic ingest APIs. */
 public class SenderConfiguration {
   private static final String DEFAULT_US_REGION = "US";
+  private static boolean userProvidedEndpoint = false;
 
   private final BaseConfig baseConfig;
   private final HttpPoster httpPoster;
@@ -80,6 +81,10 @@ public class SenderConfiguration {
     return endpointRegion;
   }
 
+  public boolean isUserProvideEndpoint() {
+    return userProvidedEndpoint;
+  }
+
   public static SenderConfigurationBuilder builder(String defaultUrl, String basePath) {
     return new SenderConfigurationBuilder(defaultUrl, basePath);
   }
@@ -124,13 +129,14 @@ public class SenderConfiguration {
 
     /**
      * Configure the *full* endpoint URL for data to be sent to, including the path. You should only
-     * use this method if you wish to modify the default behavior, which is to send data to the
-     * Portland production US endpoints.
+     * use this method if you wish to send data to endpoints other than the US and EU production endpoints.
+     *
      *
      * @param endpoint A full {@link URL}, including the path.
      * @return this builder.
      */
     public SenderConfigurationBuilder endpoint(URL endpoint) {
+      SenderConfiguration.userProvidedEndpoint = true;
       this.endpointUrl = endpoint;
       return this;
     }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -81,15 +81,13 @@ public class EventBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    URL url;
-    if (configuration.getRegion().equals("US")) {
-      url = configuration.getEndpointUrl();
-    } else {
-      try {
-        url = new URL(EUROPEAN_URL + EVENTS_PATH);
-      } catch (MalformedURLException wrongURL) {
-        url = configuration.getEndpointUrl();
-      }
+    String userRegion = configuration.getRegion();
+
+    URL url = null;
+    try {
+      url = returnEndpoint(userRegion);
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
     }
 
     EventBatchMarshaller marshaller = new EventBatchMarshaller();
@@ -104,6 +102,27 @@ public class EventBatchSender {
             configuration.useLicenseKey());
 
     return new EventBatchSender(marshaller, sender);
+  }
+
+  public static URL returnEndpoint(String userRegion) throws MalformedURLException {
+    URL url = null;
+    if (userRegion.equals("US")) {
+      try {
+        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + EVENTS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    } else if (userRegion.equals("EU")) {
+      try {
+        url = new URL(EUROPEAN_URL + EVENTS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+    throw new MalformedURLException(
+        "A valid region (EU or US) needs to be added to generate the right endpoint");
   }
 
   public static SenderConfigurationBuilder configurationBuilder() {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -15,6 +15,7 @@ import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 public class EventBatchSender {
   private static final String EVENTS_PATH = "/v1/accounts/events";
   private static final String DEFAULT_URL = "https://insights-collector.newrelic.com/";
+  private static final String EUROPEAN_URL = "https://insights-collector.eu01.nr-data.net";
   private static final Response EMPTY_BATCH_RESPONSE = new Response(202, "Ignored", "Empty batch");
 
   private static final Logger logger = LoggerFactory.getLogger(EventBatchSender.class);
@@ -79,7 +81,16 @@ public class EventBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    URL url = configuration.getEndpointUrl();
+    URL url;
+    if (configuration.getRegion().equals("US")) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = new URL(EUROPEAN_URL + EVENTS_PATH);
+      } catch (MalformedURLException wrongURL) {
+        url = configuration.getEndpointUrl();
+      }
+    }
 
     EventBatchMarshaller marshaller = new EventBatchMarshaller();
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -82,12 +82,17 @@ public class EventBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
+    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
 
     URL url = null;
-    try {
-      url = returnEndpoint(userRegion);
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
+    if (isCustomEndpoint == true) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = returnEndpoint(userRegion);
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
     }
 
     EventBatchMarshaller marshaller = new EventBatchMarshaller();
@@ -106,6 +111,7 @@ public class EventBatchSender {
 
   public static URL returnEndpoint(String userRegion) throws MalformedURLException {
     URL url = null;
+
     if (userRegion.equals("US")) {
       try {
         url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + EVENTS_PATH);

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBatchSender.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class EventBatchSender {
   private static final String EVENTS_PATH = "/v1/accounts/events";
-  private static final String DEFAULT_URL = "https://insights-collector.newrelic.com/";
+  private static final String DEFAULT_URL = "https://insights-collector.newrelic.com";
   private static final String EUROPEAN_URL = "https://insights-collector.eu01.nr-data.net";
   private static final Response EMPTY_BATCH_RESPONSE = new Response(202, "Ignored", "Empty batch");
 
@@ -82,10 +82,12 @@ public class EventBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
-    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
+
+    String defaultUrl = DEFAULT_URL + EVENTS_PATH;
+    String endpointUrlToString = configuration.getEndpointUrl().toString();
 
     URL url = null;
-    if (isCustomEndpoint == true) {
+    if (!endpointUrlToString.equals(defaultUrl)) {
       url = configuration.getEndpointUrl();
     } else {
       try {
@@ -114,7 +116,7 @@ public class EventBatchSender {
 
     if (userRegion.equals("US")) {
       try {
-        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + EVENTS_PATH);
+        url = new URL(DEFAULT_URL + EVENTS_PATH);
         return url;
       } catch (MalformedURLException e) {
         e.printStackTrace();

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -16,7 +16,6 @@ import com.newrelic.telemetry.logs.json.LogJsonCommonBlockWriter;
 import com.newrelic.telemetry.logs.json.LogJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -16,6 +16,8 @@ import com.newrelic.telemetry.logs.json.LogJsonCommonBlockWriter;
 import com.newrelic.telemetry.logs.json.LogJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
+
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -26,7 +28,7 @@ public class LogBatchSender {
 
   private static final String LOGS_PATH = "/log/v1";
   private static final String DEFAULT_URL = "https://log-api.newrelic.com/";
-
+  private static final String EUROPEAN_URL = "https://log-api.eu.newrelic.com";
   private static final Logger logger = LoggerFactory.getLogger(LogBatchSender.class);
 
   private final LogBatchMarshaller marshaller;
@@ -91,7 +93,17 @@ public class LogBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    URL url = configuration.getEndpointUrl();
+    // Get endpoint URL corresponding to user region
+    URL url;
+    if (configuration.getRegion().equals("US")) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = new URL(EUROPEAN_URL + LOGS_PATH);
+      } catch (MalformedURLException wrongURL) {
+        url = configuration.getEndpointUrl();
+      }
+    }
 
     LogBatchMarshaller marshaller =
         new LogBatchMarshaller(

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -93,12 +93,17 @@ public class LogBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
+    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
 
     URL url = null;
-    try {
-      url = returnEndpoint(userRegion);
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
+    if (isCustomEndpoint == true) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = returnEndpoint(userRegion);
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
     }
 
     LogBatchMarshaller marshaller =

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -92,16 +92,13 @@ public class LogBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    // Get endpoint URL corresponding to user region
-    URL url;
-    if (configuration.getRegion().equals("US")) {
-      url = configuration.getEndpointUrl();
-    } else {
-      try {
-        url = new URL(EUROPEAN_URL + LOGS_PATH);
-      } catch (MalformedURLException wrongURL) {
-        url = configuration.getEndpointUrl();
-      }
+    String userRegion = configuration.getRegion();
+
+    URL url = null;
+    try {
+      url = returnEndpoint(userRegion);
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
     }
 
     LogBatchMarshaller marshaller =
@@ -118,6 +115,27 @@ public class LogBatchSender {
             configuration.useLicenseKey());
 
     return new LogBatchSender(marshaller, sender);
+  }
+
+  public static URL returnEndpoint(String userRegion) throws MalformedURLException {
+    URL url = null;
+    if (userRegion.equals("US")) {
+      try {
+        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + LOGS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    } else if (userRegion.equals("EU")) {
+      try {
+        url = new URL(EUROPEAN_URL + LOGS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+    throw new MalformedURLException(
+        "A valid region (EU or US) needs to be added to generate the right endpoint");
   }
 
   public static SenderConfiguration.SenderConfigurationBuilder configurationBuilder() {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/LogBatchSender.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class LogBatchSender {
 
   private static final String LOGS_PATH = "/log/v1";
-  private static final String DEFAULT_URL = "https://log-api.newrelic.com/";
+  private static final String DEFAULT_URL = "https://log-api.newrelic.com";
   private static final String EUROPEAN_URL = "https://log-api.eu.newrelic.com";
   private static final Logger logger = LoggerFactory.getLogger(LogBatchSender.class);
 
@@ -93,10 +93,12 @@ public class LogBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
-    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
+
+    String defaultUrl = DEFAULT_URL + LOGS_PATH;
+    String endpointUrlToString = configuration.getEndpointUrl().toString();
 
     URL url = null;
-    if (isCustomEndpoint == true) {
+    if (!endpointUrlToString.equals(defaultUrl)) {
       url = configuration.getEndpointUrl();
     } else {
       try {
@@ -126,7 +128,7 @@ public class LogBatchSender {
     URL url = null;
     if (userRegion.equals("US")) {
       try {
-        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + LOGS_PATH);
+        url = new URL(DEFAULT_URL + LOGS_PATH);
         return url;
       } catch (MalformedURLException e) {
         e.printStackTrace();

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -90,16 +90,13 @@ public class MetricBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    // Get endpoint url corresponding to user region
-    URL url;
-    if (configuration.getRegion().equals("US")) {
-      url = configuration.getEndpointUrl();
-    } else {
-      try {
-        url = new URL(EUROPEAN_URL + METRICS_PATH);
-      } catch (MalformedURLException wrongURL) {
-        url = configuration.getEndpointUrl();
-      }
+    String userRegion = configuration.getRegion();
+
+    URL url = null;
+    try {
+      url = returnEndpoint(userRegion);
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
     }
 
     MetricBatchMarshaller marshaller =
@@ -116,6 +113,27 @@ public class MetricBatchSender {
             configuration.useLicenseKey());
 
     return new MetricBatchSender(marshaller, sender);
+  }
+
+  public static URL returnEndpoint(String userRegion) throws MalformedURLException {
+    URL url = null;
+    if (userRegion.equals("US")) {
+      try {
+        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + METRICS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    } else if (userRegion.equals("EU")) {
+      try {
+        url = new URL(EUROPEAN_URL + METRICS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+    throw new MalformedURLException(
+        "A valid region (EU or US) needs to be added to generate the right endpoint");
   }
 
   public static SenderConfigurationBuilder configurationBuilder() {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -18,7 +18,6 @@ import com.newrelic.telemetry.metrics.json.MetricBatchMarshaller;
 import com.newrelic.telemetry.metrics.json.MetricToJson;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;
@@ -102,7 +101,6 @@ public class MetricBatchSender {
         url = configuration.getEndpointUrl();
       }
     }
-
 
     MetricBatchMarshaller marshaller =
         new MetricBatchMarshaller(

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -18,6 +18,8 @@ import com.newrelic.telemetry.metrics.json.MetricBatchMarshaller;
 import com.newrelic.telemetry.metrics.json.MetricToJson;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
+
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -28,6 +30,7 @@ public class MetricBatchSender {
 
   private static final String METRICS_PATH = "/metric/v1";
   private static final String DEFAULT_URL = "https://metric-api.newrelic.com/";
+  private static final String EUROPEAN_URL = "https://metric-api.eu.newrelic.com";
 
   private static final Logger logger = LoggerFactory.getLogger(MetricBatchSender.class);
 
@@ -88,7 +91,18 @@ public class MetricBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    URL url = configuration.getEndpointUrl();
+    // Get endpoint url corresponding to user region
+    URL url;
+    if (configuration.getRegion().equals("US")) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = new URL(EUROPEAN_URL + METRICS_PATH);
+      } catch (MalformedURLException wrongURL) {
+        url = configuration.getEndpointUrl();
+      }
+    }
+
 
     MetricBatchMarshaller marshaller =
         new MetricBatchMarshaller(

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class MetricBatchSender {
 
   private static final String METRICS_PATH = "/metric/v1";
-  private static final String DEFAULT_URL = "https://metric-api.newrelic.com/";
+  private static final String DEFAULT_URL = "https://metric-api.newrelic.com";
   private static final String EUROPEAN_URL = "https://metric-api.eu.newrelic.com";
 
   private static final Logger logger = LoggerFactory.getLogger(MetricBatchSender.class);
@@ -91,10 +91,12 @@ public class MetricBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
-    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
+
+    String defaultUrl = DEFAULT_URL + METRICS_PATH;
+    String endpointUrlToString = configuration.getEndpointUrl().toString();
 
     URL url = null;
-    if (isCustomEndpoint == true) {
+    if (!endpointUrlToString.equals(defaultUrl)) {
       url = configuration.getEndpointUrl();
     } else {
       try {
@@ -124,7 +126,7 @@ public class MetricBatchSender {
     URL url = null;
     if (userRegion.equals("US")) {
       try {
-        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + METRICS_PATH);
+        url = new URL(DEFAULT_URL + METRICS_PATH);
         return url;
       } catch (MalformedURLException e) {
         e.printStackTrace();

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBatchSender.java
@@ -91,12 +91,17 @@ public class MetricBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
+    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
 
     URL url = null;
-    try {
-      url = returnEndpoint(userRegion);
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
+    if (isCustomEndpoint == true) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = returnEndpoint(userRegion);
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
     }
 
     MetricBatchMarshaller marshaller =

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -92,16 +92,13 @@ public class SpanBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    // Get endpoint url corresponding to user region
-    URL url;
-    if (configuration.getRegion().equals("US")) {
-      url = configuration.getEndpointUrl();
-    } else {
-      try {
-        url = new URL(EUROPEAN_URL + SPANS_PATH);
-      } catch (MalformedURLException wrongURL) {
-        url = configuration.getEndpointUrl();
-      }
+    String userRegion = configuration.getRegion();
+
+    URL url = null;
+    try {
+      url = returnEndpoint(userRegion);
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
     }
 
     SpanBatchMarshaller marshaller =
@@ -118,6 +115,27 @@ public class SpanBatchSender {
             configuration.useLicenseKey());
 
     return new SpanBatchSender(marshaller, sender);
+  }
+
+  public static URL returnEndpoint(String userRegion) throws MalformedURLException {
+    URL url = null;
+    if (userRegion.equals("US")) {
+      try {
+        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + SPANS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    } else if (userRegion.equals("EU")) {
+      try {
+        url = new URL(EUROPEAN_URL + SPANS_PATH);
+        return url;
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+    throw new MalformedURLException(
+        "A valid region (EU or US) needs to be added to generate the right endpoint");
   }
 
   public static SenderConfiguration.SenderConfigurationBuilder configurationBuilder() {

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class SpanBatchSender {
 
   private static final String SPANS_PATH = "/trace/v1";
-  private static final String DEFAULT_URL = "https://trace-api.newrelic.com/";
+  private static final String DEFAULT_URL = "https://trace-api.newrelic.com";
   private static final String EUROPEAN_URL = "https://trace-api.eu.newrelic.com";
   private static final Logger logger = LoggerFactory.getLogger(SpanBatchSender.class);
 
@@ -93,10 +93,11 @@ public class SpanBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
-    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
+    String defaultUrl = DEFAULT_URL + SPANS_PATH;
+    String endpointUrlToString = configuration.getEndpointUrl().toString();
 
     URL url = null;
-    if (isCustomEndpoint == true) {
+    if (!endpointUrlToString.equals(defaultUrl)) {
       url = configuration.getEndpointUrl();
     } else {
       try {
@@ -126,7 +127,7 @@ public class SpanBatchSender {
     URL url = null;
     if (userRegion.equals("US")) {
       try {
-        url = new URL(DEFAULT_URL.substring(0, DEFAULT_URL.length() - 1) + SPANS_PATH);
+        url = new URL(DEFAULT_URL + SPANS_PATH);
         return url;
       } catch (MalformedURLException e) {
         e.printStackTrace();

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -93,12 +93,17 @@ public class SpanBatchSender {
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
     String userRegion = configuration.getRegion();
+    boolean isCustomEndpoint = configuration.isUserProvideEndpoint();
 
     URL url = null;
-    try {
-      url = returnEndpoint(userRegion);
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
+    if (isCustomEndpoint == true) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = returnEndpoint(userRegion);
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
     }
 
     SpanBatchMarshaller marshaller =

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -16,7 +16,6 @@ import com.newrelic.telemetry.spans.json.SpanJsonCommonBlockWriter;
 import com.newrelic.telemetry.spans.json.SpanJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/spans/SpanBatchSender.java
@@ -16,6 +16,8 @@ import com.newrelic.telemetry.spans.json.SpanJsonCommonBlockWriter;
 import com.newrelic.telemetry.spans.json.SpanJsonTelemetryBlockWriter;
 import com.newrelic.telemetry.transport.BatchDataSender;
 import com.newrelic.telemetry.util.Utils;
+
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -26,7 +28,7 @@ public class SpanBatchSender {
 
   private static final String SPANS_PATH = "/trace/v1";
   private static final String DEFAULT_URL = "https://trace-api.newrelic.com/";
-
+  private static final String EUROPEAN_URL = "https://trace-api.eu.newrelic.com";
   private static final Logger logger = LoggerFactory.getLogger(SpanBatchSender.class);
 
   private final SpanBatchMarshaller marshaller;
@@ -91,7 +93,17 @@ public class SpanBatchSender {
     Utils.verifyNonNull(configuration.getApiKey(), "API key cannot be null");
     Utils.verifyNonNull(configuration.getHttpPoster(), "an HttpPoster implementation is required.");
 
-    URL url = configuration.getEndpointUrl();
+    // Get endpoint url corresponding to user region
+    URL url;
+    if (configuration.getRegion().equals("US")) {
+      url = configuration.getEndpointUrl();
+    } else {
+      try {
+        url = new URL(EUROPEAN_URL + SPANS_PATH);
+      } catch (MalformedURLException wrongURL) {
+        url = configuration.getEndpointUrl();
+      }
+    }
 
     SpanBatchMarshaller marshaller =
         new SpanBatchMarshaller(

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
@@ -2,6 +2,7 @@ package com.newrelic.telemetry;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.net.URL;
 import org.junit.jupiter.api.Test;
 
 class SenderConfigurationTest {
@@ -32,5 +33,36 @@ class SenderConfigurationTest {
             });
     String expectedExceptionMessage = "The only supported regions are the US and EU regions";
     assertEquals(expectedExceptionMessage, testIllegalArgumentException.getMessage());
+  }
+
+  @Test
+  void defaultEndpointTest() throws Exception {
+    URL testEndpointURL = new URL(testURL + testPath);
+    SenderConfiguration testConfig = SenderConfiguration.builder(testURL, testPath).build();
+    assertEquals(testEndpointURL, testConfig.getEndpointUrl());
+  }
+
+  @Test
+  void userProvidedEndpointTest() throws Exception {
+    URL testEndpointURL = new URL("https://google.com");
+    SenderConfiguration testConfig =
+        SenderConfiguration.builder(testURL, testPath).endpoint(testEndpointURL).build();
+    assertEquals(testEndpointURL, testConfig.getEndpointUrl());
+  }
+
+  @Test
+  void defaultEndpointAsStringTest() throws Exception {
+    String endpointURLAsString = testURL + testPath;
+    SenderConfiguration testConfig = SenderConfiguration.builder(testURL, testPath).build();
+    assertEquals(endpointURLAsString, testConfig.getEndpointUrl().toString());
+  }
+
+  @Test
+  void userEndpointAsStringTest() throws Exception {
+    URL testEndpointURL = new URL("https://google.com");
+    String endpointURLAsString = "https://google.com";
+    SenderConfiguration testConfig =
+        SenderConfiguration.builder(testURL, testPath).endpoint(testEndpointURL).build();
+    assertEquals(endpointURLAsString, testConfig.getEndpointUrl().toString());
   }
 }

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
@@ -1,0 +1,36 @@
+package com.newrelic.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SenderConfigurationTest {
+
+  String testURL = "https://fun.com";
+  String testPath = "/account/metric";
+
+  @Test
+  void defaultRegionTest() {
+    SenderConfiguration testConfig = SenderConfiguration.builder(testURL, testPath).build();
+    assertEquals("US", testConfig.getRegion());
+  }
+
+  @Test
+  void defaultEURegionTest() {
+    SenderConfiguration testEUConfig =
+        SenderConfiguration.builder(testURL, testPath).setRegion("EU").build();
+    assertEquals("EU", testEUConfig.getRegion());
+  }
+
+  @Test
+  void exceptionTest() {
+    Exception testIllegalArgumentException =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              SenderConfiguration.builder(testURL, testPath).setRegion("ASIA").build();
+            });
+    String expectedExceptionMessage = "The only supported regions are the US and EU regions";
+    assertEquals(expectedExceptionMessage, testIllegalArgumentException.getMessage());
+  }
+}

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/SenderConfigurationTest.java
@@ -49,20 +49,4 @@ class SenderConfigurationTest {
         SenderConfiguration.builder(testURL, testPath).endpoint(testEndpointURL).build();
     assertEquals(testEndpointURL, testConfig.getEndpointUrl());
   }
-
-  @Test
-  void defaultEndpointAsStringTest() throws Exception {
-    String endpointURLAsString = testURL + testPath;
-    SenderConfiguration testConfig = SenderConfiguration.builder(testURL, testPath).build();
-    assertEquals(endpointURLAsString, testConfig.getEndpointUrl().toString());
-  }
-
-  @Test
-  void userEndpointAsStringTest() throws Exception {
-    URL testEndpointURL = new URL("https://google.com");
-    String endpointURLAsString = "https://google.com";
-    SenderConfiguration testConfig =
-        SenderConfiguration.builder(testURL, testPath).endpoint(testEndpointURL).build();
-    assertEquals(endpointURLAsString, testConfig.getEndpointUrl().toString());
-  }
 }


### PR DESCRIPTION
The following PR adds the .setRegion() method to the SenderConfigurationBuilder API. This method allows you to define a region (US or EU) so that the appropriate production endpoint (corresponding to that region) is used. The default endpoint is the US production endpoint. 

If you want to use an endpoint other than the US / EU production endpoints, use the existing .endpoint() method in the SenderConfigurationBuilder API. 

Below are some examples on how to use the new API. In these examples, we use the MetricBatchSender / MetricBatchSenderFactory. 

**US Production**

```java

String licenseKey = args[0];
MetricBatchSenderFactory factory = MetricBatchSenderFactory.fromHttpImplementation(OkHttpPoster::new);
MetricBatchSender sender = MetricBatchSender.create(factory.configureWith(licenseKey).useLicenseKey(true).build());
```

Note: Since the default endpoint is the US production endpoint, we did not use .setRegion() in this example. Also, a US license key is needed to send data to this endpoint.

**EU Production** 

```java 

String licenseKey = args[0];
MetricBatchSenderFactory factory = MetricBatchSenderFactory.fromHttpImplementation(OkHttpPoster::new);
MetricBatchSender sender = MetricBatchSender.create(factory.configureWith(licenseKey).useLicenseKey(true).setRegion("EU").build());
```

Note: An EU license key is needed to send data to this endpoint. 

**Staging / Setting Your Own URL**

```java 

URL endpointURL = new URL("http://localhost:1439/v1/accounts/events");
String licenseKey = args[0];
MetricBatchSenderFactory factory = MetricBatchSenderFactory.fromHttpImplementation(OkHttpPoster::new);
MetricBatchSender sender =
    MetricBatchSender.create(factory.configureWith(licenseKey).useLicenseKey(true).endpoint(endpointURL).build());
```

