### PR TITLE
Initial commit of IngestWarnings file (checking Ingest API limits) and associated uses in the SDK

### DIFF
--- a/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
@@ -8,6 +8,7 @@ import static java.util.Collections.unmodifiableMap;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A collection of key-value pairs that can be used as the dimensional attributes for metrics.
@@ -86,6 +87,27 @@ public class Attributes {
   }
 
   /**
+   * Remove a attribute and its value.
+   *
+   * @param key to locate the value
+   * @return this
+   */
+  public Attributes remove(String key) {
+    rawAttributes.remove(key);
+    return this;
+  }
+
+  /**
+   * Get the value of an attribute.
+   *
+   * @param key to locate the value
+   * @return this
+   */
+  public Object get(String key) {
+    return rawAttributes.get(key);
+  }
+
+  /**
    * Make a copy of these attributes.
    *
    * @return An unmodifiable copy of these attributes, as a Map.
@@ -97,6 +119,16 @@ public class Attributes {
   /** @return true if there are no attributes in this Attributes instance */
   public boolean isEmpty() {
     return rawAttributes.isEmpty();
+  }
+
+  /** @return number of attributes */
+  public int numAttributes() {
+    return rawAttributes.size();
+  }
+
+  /** @return attribute names */
+  public Set<String> attributeNames() {
+    return rawAttributes.keySet();
   }
 
   @Override

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
@@ -8,7 +8,6 @@ import static java.util.Collections.unmodifiableMap;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A collection of key-value pairs that can be used as the dimensional attributes for metrics.
@@ -87,17 +86,6 @@ public class Attributes {
   }
 
   /**
-   * Remove a attribute and its value.
-   *
-   * @param key to locate the value
-   * @return this
-   */
-  public Attributes remove(String key) {
-    rawAttributes.remove(key);
-    return this;
-  }
-
-  /**
    * Get the value of an attribute.
    *
    * @param key to locate the value
@@ -119,16 +107,6 @@ public class Attributes {
   /** @return true if there are no attributes in this Attributes instance */
   public boolean isEmpty() {
     return rawAttributes.isEmpty();
-  }
-
-  /** @return number of attributes */
-  public int numAttributes() {
-    return rawAttributes.size();
-  }
-
-  /** @return attribute names */
-  public Set<String> attributeNames() {
-    return rawAttributes.keySet();
   }
 
   @Override

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/Attributes.java
@@ -86,16 +86,6 @@ public class Attributes {
   }
 
   /**
-   * Get the value of an attribute.
-   *
-   * @param key to locate the value
-   * @return this
-   */
-  public Object get(String key) {
-    return rawAttributes.get(key);
-  }
-
-  /**
    * Make a copy of these attributes.
    *
    * @return An unmodifiable copy of these attributes, as a Map.

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
@@ -41,7 +41,7 @@ public final class EventBuffer {
    */
   public void addEvent(Event event) {
     Map<String, Object> attributes = event.getAttributes().asMap();
-    ingestWarnings.raiseIngestWarnings(attributes, "Event");
+    ingestWarnings.raiseIngestWarnings(attributes, event);
     events.add(event);
   }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
@@ -20,9 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class EventBuffer {
   private static final Logger logger = LoggerFactory.getLogger(EventBuffer.class);
-  private static final int maxNumberOfAttributes = 254;
-  private static final int maxAttributeNameLength = 255;
-  private static final int maxAttributeValueLength = 4096;
   private final Queue<Event> events = new ConcurrentLinkedQueue<>();
   private final IngestWarnings ingestWarnings = new IngestWarnings();
   private final Attributes commonAttributes;
@@ -44,11 +41,7 @@ public final class EventBuffer {
    */
   public void addEvent(Event event) {
     Map<String, Object> attributes = event.getAttributes().asMap();
-
-    ingestWarnings.isValidNumberOfAttributes(attributes, "Event");
-    ingestWarnings.validAttributeNames(attributes);
-    ingestWarnings.validAttributeValues(attributes);
-
+    ingestWarnings.raiseIngestWarnings(attributes, "Event");
     events.add(event);
   }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/events/EventBuffer.java
@@ -5,10 +5,9 @@
 package com.newrelic.telemetry.events;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.util.IngestWarnings;
 import com.newrelic.telemetry.util.Utils;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,9 +20,11 @@ import org.slf4j.LoggerFactory;
  */
 public final class EventBuffer {
   private static final Logger logger = LoggerFactory.getLogger(EventBuffer.class);
-
+  private static final int maxNumberOfAttributes = 254;
+  private static final int maxAttributeNameLength = 255;
+  private static final int maxAttributeValueLength = 4096;
   private final Queue<Event> events = new ConcurrentLinkedQueue<>();
-
+  private final IngestWarnings ingestWarnings = new IngestWarnings();
   private final Attributes commonAttributes;
 
   /**
@@ -42,6 +43,12 @@ public final class EventBuffer {
    * @param event The new {@link Event} instance to be sent.
    */
   public void addEvent(Event event) {
+    Map<String, Object> attributes = event.getAttributes().asMap();
+
+    ingestWarnings.isValidNumberOfAttributes(attributes, "Event");
+    ingestWarnings.validAttributeNames(attributes);
+    ingestWarnings.validAttributeValues(attributes);
+
     events.add(event);
   }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -9,7 +9,6 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.Telemetry;
 import com.newrelic.telemetry.util.IngestWarnings;
 import com.newrelic.telemetry.util.Utils;
-import java.util.Map;
 
 /** A Log instance represents a single entry in a log. */
 public class Log implements Telemetry {
@@ -160,9 +159,6 @@ public class Log implements Telemetry {
      * @return log builder instance
      */
     public LogBuilder attributes(Attributes attributes) {
-      Map<String, Object> attrs = attributes.asMap();
-      ingestWarnings.raiseIngestWarnings(attrs, "Log");
-
       this.attributes = attributes;
       return this;
     }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -160,11 +160,8 @@ public class Log implements Telemetry {
      * @return log builder instance
      */
     public LogBuilder attributes(Attributes attributes) {
-
       Map<String, Object> attrs = attributes.asMap();
-      ingestWarnings.isValidNumberOfAttributes(attrs, "Log");
-      ingestWarnings.validAttributeNames(attrs);
-      ingestWarnings.validAttributeValues(attrs);
+      ingestWarnings.raiseIngestWarnings(attrs, "Log");
 
       this.attributes = attributes;
       return this;

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/logs/Log.java
@@ -7,7 +7,9 @@ package com.newrelic.telemetry.logs;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.Telemetry;
+import com.newrelic.telemetry.util.IngestWarnings;
 import com.newrelic.telemetry.util.Utils;
+import java.util.Map;
 
 /** A Log instance represents a single entry in a log. */
 public class Log implements Telemetry {
@@ -130,6 +132,7 @@ public class Log implements Telemetry {
     private long timestamp = System.currentTimeMillis();
     private String message;
     private Attributes attributes = new Attributes();
+    private IngestWarnings ingestWarnings = new IngestWarnings();
     private String serviceName; // service.name <- goes in attributes
     private String level;
     private Throwable throwable;
@@ -157,6 +160,12 @@ public class Log implements Telemetry {
      * @return log builder instance
      */
     public LogBuilder attributes(Attributes attributes) {
+
+      Map<String, Object> attrs = attributes.asMap();
+      ingestWarnings.isValidNumberOfAttributes(attrs, "Log");
+      ingestWarnings.validAttributeNames(attrs);
+      ingestWarnings.validAttributeValues(attrs);
+
       this.attributes = attributes;
       return this;
     }
@@ -181,6 +190,7 @@ public class Log implements Telemetry {
 
     /** @return Create the new {@link Log} entry. */
     public Log build() {
+
       return new Log(this, throwable);
     }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
@@ -5,9 +5,11 @@
 package com.newrelic.telemetry.metrics;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.util.IngestWarnings;
 import com.newrelic.telemetry.util.Utils;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.LoggerFactory;
@@ -23,9 +25,9 @@ import org.slf4j.LoggerFactory;
  */
 public final class MetricBuffer {
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(MetricBuffer.class);
-
+  private static final int maxMetricAttributes = 100;
   private final Queue<Metric> metrics = new ConcurrentLinkedQueue<>();
-
+  private final IngestWarnings ingestWarnings = new IngestWarnings();
   private final Attributes commonAttributes;
 
   /**
@@ -44,7 +46,38 @@ public final class MetricBuffer {
    * @param metric The new {@link Metric} instance to be sent.
    */
   public void addMetric(Metric metric) {
+    System.out.println(metric.getClass());
     metrics.add(metric);
+  }
+
+  public void addMetric(Count countMetric) {
+    Map<String, Object> attributes = countMetric.getAttributes();
+
+    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
+    ingestWarnings.validAttributeNames(attributes);
+    ingestWarnings.validAttributeValues(attributes);
+
+    metrics.add(countMetric);
+  }
+
+  public void addMetric(Gauge gaugeMetric) {
+    Map<String, Object> attributes = gaugeMetric.getAttributes();
+
+    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
+    ingestWarnings.validAttributeNames(attributes);
+    ingestWarnings.validAttributeValues(attributes);
+
+    metrics.add(gaugeMetric);
+  }
+
+  public void addMetric(Summary summaryMetric) {
+    Map<String, Object> attributes = summaryMetric.getAttributes();
+
+    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
+    ingestWarnings.validAttributeNames(attributes);
+    ingestWarnings.validAttributeValues(attributes);
+
+    metrics.add(summaryMetric);
   }
 
   /**

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
@@ -46,7 +46,7 @@ public final class MetricBuffer {
    */
   public void addMetric(Count countMetric) {
     Map<String, Object> attributes = countMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
+    ingestWarnings.raiseIngestWarnings(attributes, countMetric);
     metrics.add(countMetric);
   }
 
@@ -57,7 +57,7 @@ public final class MetricBuffer {
    */
   public void addMetric(Gauge gaugeMetric) {
     Map<String, Object> attributes = gaugeMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
+    ingestWarnings.raiseIngestWarnings(attributes, gaugeMetric);
     metrics.add(gaugeMetric);
   }
 
@@ -68,7 +68,7 @@ public final class MetricBuffer {
    */
   public void addMetric(Summary summaryMetric) {
     Map<String, Object> attributes = summaryMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
+    ingestWarnings.raiseIngestWarnings(attributes, summaryMetric);
     metrics.add(summaryMetric);
   }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class MetricBuffer {
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(MetricBuffer.class);
-  private static final int maxMetricAttributes = 100;
   private final Queue<Metric> metrics = new ConcurrentLinkedQueue<>();
   private final IngestWarnings ingestWarnings = new IngestWarnings();
   private final Attributes commonAttributes;
@@ -41,42 +40,35 @@ public final class MetricBuffer {
   }
 
   /**
-   * Append a {@link Metric} to this buffer, to be sent in the next {@link MetricBatch}.
+   * Append a {@link Count} to this buffer, to be sent in the next {@link MetricBatch}.
    *
-   * @param metric The new {@link Metric} instance to be sent.
+   * @param countMetric The new {@link Count} instance to be sent.
    */
-  public void addMetric(Metric metric) {
-    System.out.println(metric.getClass());
-    metrics.add(metric);
-  }
-
   public void addMetric(Count countMetric) {
     Map<String, Object> attributes = countMetric.getAttributes();
-
-    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
-    ingestWarnings.validAttributeNames(attributes);
-    ingestWarnings.validAttributeValues(attributes);
-
+    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
     metrics.add(countMetric);
   }
 
+  /**
+   * Append a {@link Gauge} to this buffer, to be sent in the next {@link MetricBatch}.
+   *
+   * @param gaugeMetric The new {@link Gauge} instance to be sent.
+   */
   public void addMetric(Gauge gaugeMetric) {
     Map<String, Object> attributes = gaugeMetric.getAttributes();
-
-    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
-    ingestWarnings.validAttributeNames(attributes);
-    ingestWarnings.validAttributeValues(attributes);
-
+    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
     metrics.add(gaugeMetric);
   }
 
+  /**
+   * Append a {@link Summary} to this buffer, to be sent in the next {@link MetricBatch}.
+   *
+   * @param summaryMetric The new {@link Summary} instance to be sent.
+   */
   public void addMetric(Summary summaryMetric) {
     Map<String, Object> attributes = summaryMetric.getAttributes();
-
-    ingestWarnings.isValidNumberOfAttributes(attributes, "Metric");
-    ingestWarnings.validAttributeNames(attributes);
-    ingestWarnings.validAttributeValues(attributes);
-
+    ingestWarnings.raiseIngestWarnings(attributes, "Metric");
     metrics.add(summaryMetric);
   }
 

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
@@ -1,0 +1,84 @@
+package com.newrelic.telemetry.util;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IngestWarnings {
+  private static final Logger logger = LoggerFactory.getLogger(IngestWarnings.class);
+  private static final int maxNumberOfEventAttributes = 254;
+  private static final int maxNumberOfMetricAttributes = 100;
+  private static final int maxNumberOfLogAttributes = 254;
+
+  private static final int maxAttributeNameLength = 255;
+  private static final int maxAttributeValueLength = 4096;
+
+  private static final String validEventTypeRegex = "^[a-zA-Z0-9_:]";
+
+  public void eventWarningNumAttributes() {
+    logger.warn(
+        "The number of attributes in this event is greater than the maximum allowed attributes per event.");
+  }
+
+  public void metricWarningNumAttributes() {
+    logger.warn(
+        "The number of attributes in this metric is greater than the maximum allowed attributes per metric.");
+  }
+
+  public void logWarningNumAttributes() {
+    logger.warn(
+        "The number of attributes in this log is greater than the maximum allowed attributes per log.");
+  }
+
+  public void isValidNumberOfAttributes(Map<String, Object> attributes, String dataType) {
+    int numberOfAttributes = attributes.size();
+    if (dataType.equals("Event")) {
+      if (numberOfAttributes > maxNumberOfEventAttributes) {
+        eventWarningNumAttributes();
+      }
+    }
+    if (dataType.equals("Metric")) {
+      if (numberOfAttributes > maxNumberOfMetricAttributes) {
+        metricWarningNumAttributes();
+      }
+    }
+    if (dataType.equals("Log")) {
+      if (numberOfAttributes > maxNumberOfLogAttributes) {
+        logWarningNumAttributes();
+      }
+    }
+  }
+
+  public void attributeNameWarning(String attributeName) {
+    logger.warn(
+        "The length of the attribute named "
+            + attributeName
+            + " is greater than the maximum length allowed for an attribute name.");
+  }
+
+  public void validAttributeNames(Map<String, Object> attributes) {
+    for (String attributeName : attributes.keySet()) {
+      if (attributeName.length() > maxAttributeNameLength) {
+        attributeNameWarning(attributeName);
+      }
+    }
+  }
+
+  public void attributeValueWarning(String attributeValue) {
+    logger.warn(
+        "The value of the attribute "
+            + attributeValue
+            + " is greater than the maximum length allowed for an attribute value.");
+  }
+
+  public void validAttributeValues(Map<String, Object> attributes) {
+    for (String attributeName : attributes.keySet()) {
+      if (attributes.get(attributeName) instanceof String) {
+        String attributeValue = attributes.get(attributeName).toString();
+        if (attributeValue.length() > maxAttributeValueLength) {
+          attributeValueWarning(attributeValue);
+        }
+      }
+    }
+  }
+}

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
@@ -58,8 +58,10 @@ public class IngestWarnings {
 
   public void validAttributeNames(Map<String, Object> attributes) {
     for (String attributeName : attributes.keySet()) {
-      if (attributeName.length() > maxAttributeNameLength) {
-        attributeNameWarning(attributeName);
+      if (attributeName != null) {
+        if (attributeName.length() > maxAttributeNameLength) {
+          attributeNameWarning(attributeName);
+        }
       }
     }
   }
@@ -73,10 +75,12 @@ public class IngestWarnings {
 
   public void validAttributeValues(Map<String, Object> attributes) {
     for (String attributeName : attributes.keySet()) {
-      if (attributes.get(attributeName) instanceof String) {
-        String attributeValue = attributes.get(attributeName).toString();
-        if (attributeValue.length() > maxAttributeValueLength) {
-          attributeValueWarning(attributeValue);
+      if (attributeName != null) {
+        if (attributes.get(attributeName) instanceof String) {
+          String attributeValue = attributes.get(attributeName).toString();
+          if (attributeValue.length() > maxAttributeValueLength) {
+            attributeValueWarning(attributeValue);
+          }
         }
       }
     }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
@@ -1,5 +1,9 @@
 package com.newrelic.telemetry.util;
 
+import com.newrelic.telemetry.Telemetry;
+import com.newrelic.telemetry.events.Event;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.metrics.Metric;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,61 +11,34 @@ import org.slf4j.LoggerFactory;
 public class IngestWarnings {
   private static final Logger logger = LoggerFactory.getLogger(IngestWarnings.class);
   private static final int MAX_NUMBER_OF_EVENT_ATTRIBUTES =
-      254; // Public documentation says 255, but true maximum is 254
+      254; // Public documentation says 255, but true maximum is 254. This is referenced in the
+  // following Slack thread: https://newrelic.slack.com/archives/CAHBUB7A9/p1625002090399400.
   private static final int MAX_NUMBER_OF_METRIC_ATTRIBUTES = 100;
   private static final int MAX_NUMBER_OF_LOG_ATTRIBUTES =
-      254; // Public documentation says 255, but true maximum is 254
+      254; // Public documentation says 255, but true maximum is 254. This is reference in the
+  // following Slack thread: https://newrelic.slack.com/archives/CAHBUB7A9/p1625002090399400
 
   private static final int MAX_ATTRIBUTE_NAME_LENGTH = 255;
   private static final int MAX_ATTRIBUTE_VALUE_LENGTH = 4096;
 
-  public void eventWarningNumAttributes() {
-    logger.warn(
-        "The number of attributes in this event is greater than the maximum allowed attributes per event.");
-  }
-
-  public void metricWarningNumAttributes() {
-    logger.warn(
-        "The number of attributes in this metric is greater than the maximum allowed attributes per metric.");
-  }
-
-  public void logWarningNumAttributes() {
-    logger.warn(
-        "The number of attributes in this log is greater than the maximum allowed attributes per log.");
-  }
-
-  public void attributeNameWarning(String attributeName) {
-    logger.warn(
-        "The length of the attribute named "
-            + attributeName
-            + " is greater than the maximum length allowed for an attribute name.");
-  }
-
-  public void attributeValueWarning(String attributeValue) {
-    logger.warn(
-        "The value of the attribute "
-            + attributeValue
-            + " is greater than the maximum length allowed for an attribute value.");
-  }
-
-  public void raiseIngestWarnings(Map<String, Object> attributes, String dataType) {
+  public void raiseIngestWarnings(Map<String, Object> attributes, Telemetry dataType) {
 
     // First Check - Check for valid number of attributes
 
     int numberOfAttributes = attributes.size();
-    if (dataType.equals("Event")) {
+    if (dataType instanceof Event) {
       if (numberOfAttributes > MAX_NUMBER_OF_EVENT_ATTRIBUTES) {
-        eventWarningNumAttributes();
+        warningNumAttributes("Event");
       }
     }
-    if (dataType.equals("Metric")) {
+    if (dataType instanceof Metric) {
       if (numberOfAttributes > MAX_NUMBER_OF_METRIC_ATTRIBUTES) {
-        metricWarningNumAttributes();
+        warningNumAttributes("Metric");
       }
     }
-    if (dataType.equals("Log")) {
+    if (dataType instanceof Log) {
       if (numberOfAttributes > MAX_NUMBER_OF_LOG_ATTRIBUTES) {
-        logWarningNumAttributes();
+        warningNumAttributes("Log");
       }
     }
 
@@ -87,5 +64,24 @@ public class IngestWarnings {
         }
       }
     }
+  }
+
+  public void warningNumAttributes(String telemetryType) {
+    logger.warn(
+        "The number of attributes in this {} is greater than the maximum allowed attributes per {}.",
+        telemetryType,
+        telemetryType);
+  }
+
+  public void attributeNameWarning(String attributeName) {
+    logger.warn(
+        "The length of the attribute named {} is greater than the maximum length allowed for an attribute name.",
+        attributeName);
+  }
+
+  public void attributeValueWarning(String attributeValue) {
+    logger.warn(
+        "The value of the attribute, {}, is greater than the maximum length allowed for an attribute value.",
+        attributeValue);
   }
 }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/IngestWarnings.java
@@ -6,14 +6,14 @@ import org.slf4j.LoggerFactory;
 
 public class IngestWarnings {
   private static final Logger logger = LoggerFactory.getLogger(IngestWarnings.class);
-  private static final int maxNumberOfEventAttributes = 254;
-  private static final int maxNumberOfMetricAttributes = 100;
-  private static final int maxNumberOfLogAttributes = 254;
+  private static final int MAX_NUMBER_OF_EVENT_ATTRIBUTES =
+      254; // Public documentation says 255, but true maximum is 254
+  private static final int MAX_NUMBER_OF_METRIC_ATTRIBUTES = 100;
+  private static final int MAX_NUMBER_OF_LOG_ATTRIBUTES =
+      254; // Public documentation says 255, but true maximum is 254
 
-  private static final int maxAttributeNameLength = 255;
-  private static final int maxAttributeValueLength = 4096;
-
-  private static final String validEventTypeRegex = "^[a-zA-Z0-9_:]";
+  private static final int MAX_ATTRIBUTE_NAME_LENGTH = 255;
+  private static final int MAX_ATTRIBUTE_VALUE_LENGTH = 4096;
 
   public void eventWarningNumAttributes() {
     logger.warn(
@@ -30,40 +30,11 @@ public class IngestWarnings {
         "The number of attributes in this log is greater than the maximum allowed attributes per log.");
   }
 
-  public void isValidNumberOfAttributes(Map<String, Object> attributes, String dataType) {
-    int numberOfAttributes = attributes.size();
-    if (dataType.equals("Event")) {
-      if (numberOfAttributes > maxNumberOfEventAttributes) {
-        eventWarningNumAttributes();
-      }
-    }
-    if (dataType.equals("Metric")) {
-      if (numberOfAttributes > maxNumberOfMetricAttributes) {
-        metricWarningNumAttributes();
-      }
-    }
-    if (dataType.equals("Log")) {
-      if (numberOfAttributes > maxNumberOfLogAttributes) {
-        logWarningNumAttributes();
-      }
-    }
-  }
-
   public void attributeNameWarning(String attributeName) {
     logger.warn(
         "The length of the attribute named "
             + attributeName
             + " is greater than the maximum length allowed for an attribute name.");
-  }
-
-  public void validAttributeNames(Map<String, Object> attributes) {
-    for (String attributeName : attributes.keySet()) {
-      if (attributeName != null) {
-        if (attributeName.length() > maxAttributeNameLength) {
-          attributeNameWarning(attributeName);
-        }
-      }
-    }
   }
 
   public void attributeValueWarning(String attributeValue) {
@@ -73,12 +44,44 @@ public class IngestWarnings {
             + " is greater than the maximum length allowed for an attribute value.");
   }
 
-  public void validAttributeValues(Map<String, Object> attributes) {
+  public void raiseIngestWarnings(Map<String, Object> attributes, String dataType) {
+
+    // First Check - Check for valid number of attributes
+
+    int numberOfAttributes = attributes.size();
+    if (dataType.equals("Event")) {
+      if (numberOfAttributes > MAX_NUMBER_OF_EVENT_ATTRIBUTES) {
+        eventWarningNumAttributes();
+      }
+    }
+    if (dataType.equals("Metric")) {
+      if (numberOfAttributes > MAX_NUMBER_OF_METRIC_ATTRIBUTES) {
+        metricWarningNumAttributes();
+      }
+    }
+    if (dataType.equals("Log")) {
+      if (numberOfAttributes > MAX_NUMBER_OF_LOG_ATTRIBUTES) {
+        logWarningNumAttributes();
+      }
+    }
+
+    // Second Check - Check that the attribute names are valid
+
+    for (String attributeName : attributes.keySet()) {
+      if (attributeName != null) {
+        if (attributeName.length() > MAX_ATTRIBUTE_NAME_LENGTH) {
+          attributeNameWarning(attributeName);
+        }
+      }
+    }
+
+    // Third Check - Check that the attribute values are valid
+
     for (String attributeName : attributes.keySet()) {
       if (attributeName != null) {
         if (attributes.get(attributeName) instanceof String) {
           String attributeValue = attributes.get(attributeName).toString();
-          if (attributeValue.length() > maxAttributeValueLength) {
+          if (attributeValue.length() > MAX_ATTRIBUTE_VALUE_LENGTH) {
             attributeValueWarning(attributeValue);
           }
         }

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
@@ -1,0 +1,164 @@
+package com.newrelic.telemetry.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class IngestWarningsTest {
+
+  @Test
+  void validNumberOfAttributesForEventTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Event");
+    verify(testIngestWarnings, never()).eventWarningNumAttributes();
+  }
+
+  @Test
+  void invalidNumberOfAttributesForEventTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+
+    for (int i = 0; i < 300; i++) {
+      testAttributes.put("Attribute" + i, i);
+    }
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Event");
+    verify(testIngestWarnings).eventWarningNumAttributes();
+  }
+
+  @Test
+  void validNumberOfAttributesForMetricTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Metric");
+    verify(testIngestWarnings, never()).metricWarningNumAttributes();
+  }
+
+  @Test
+  void invalidNumberOfAttributesForMetricTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    for (int i = 0; i < 110; i++) {
+      testAttributes.put("Attribute" + i, i);
+    }
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Metric");
+    verify(testIngestWarnings).metricWarningNumAttributes();
+  }
+
+  @Test
+  void validNumberOfAttributesForLogTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Log");
+    verify(testIngestWarnings, never()).logWarningNumAttributes();
+  }
+
+  @Test
+  void invalidNumberOfAttributesForLogTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+
+    for (int i = 0; i < 300; i++) {
+      testAttributes.put("Attribute" + i, i);
+    }
+
+    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Log");
+    verify(testIngestWarnings).logWarningNumAttributes();
+  }
+
+  // add # of attributes test(s) for logs
+
+  @Test
+  void validAttributeNamesTest() {
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.validAttributeNames(testAttributes);
+    verify(testIngestWarnings, never()).attributeNameWarning("test");
+  }
+
+  @Test
+  void invalidAttributeNamesTest() {
+
+    String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    StringBuilder sb = new StringBuilder();
+    Random random = new Random();
+    int length = 300;
+
+    for (int i = 0; i < length; i++) {
+      int index = random.nextInt(alphabet.length());
+      char randomChar = alphabet.charAt(index);
+      sb.append(randomChar);
+    }
+
+    String longAttrName = sb.toString();
+
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put(longAttrName, 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.validAttributeNames(testAttributes);
+    verify(testIngestWarnings).attributeNameWarning(longAttrName);
+  }
+
+  @Test
+  void validAttributeValuesTest() {
+
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", 1);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.validAttributeValues(testAttributes);
+    verify(testIngestWarnings, never()).attributeValueWarning("test");
+  }
+
+  @Test
+  void invalidAttributeValuesTest() {
+    String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    StringBuilder sb = new StringBuilder();
+    Random random = new Random();
+    int length = 5000;
+
+    for (int i = 0; i < length; i++) {
+      int index = random.nextInt(alphabet.length());
+      char randomChar = alphabet.charAt(index);
+      sb.append(randomChar);
+    }
+
+    String longAttrValue = sb.toString();
+
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put("test", longAttrValue);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.validAttributeValues(testAttributes);
+    verify(testIngestWarnings).attributeValueWarning(longAttrValue);
+  }
+}

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
@@ -18,7 +18,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Event");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
     verify(testIngestWarnings, never()).eventWarningNumAttributes();
   }
 
@@ -31,7 +31,7 @@ class IngestWarningsTest {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Event");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
     verify(testIngestWarnings).eventWarningNumAttributes();
   }
 
@@ -43,7 +43,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Metric");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Metric");
     verify(testIngestWarnings, never()).metricWarningNumAttributes();
   }
 
@@ -55,7 +55,7 @@ class IngestWarningsTest {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Metric");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Metric");
     verify(testIngestWarnings).metricWarningNumAttributes();
   }
 
@@ -67,7 +67,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Log");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Log");
     verify(testIngestWarnings, never()).logWarningNumAttributes();
   }
 
@@ -80,7 +80,7 @@ class IngestWarningsTest {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.isValidNumberOfAttributes(testAttributes, "Log");
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Log");
     verify(testIngestWarnings).logWarningNumAttributes();
   }
 
@@ -94,7 +94,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.validAttributeNames(testAttributes);
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
     verify(testIngestWarnings, never()).attributeNameWarning("test");
   }
 
@@ -120,7 +120,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.validAttributeNames(testAttributes);
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
     verify(testIngestWarnings).attributeNameWarning(longAttrName);
   }
 
@@ -133,7 +133,7 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.validAttributeValues(testAttributes);
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
     verify(testIngestWarnings, never()).attributeValueWarning("test");
   }
 
@@ -158,7 +158,34 @@ class IngestWarningsTest {
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.validAttributeValues(testAttributes);
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    verify(testIngestWarnings).attributeValueWarning(longAttrValue);
+  }
+
+  @Test
+  void invalidAttributeNameAndValueTest() {
+    String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    StringBuilder sb = new StringBuilder();
+    Random random = new Random();
+    int length = 5000;
+
+    for (int i = 0; i < length; i++) {
+      int index = random.nextInt(alphabet.length());
+      char randomChar = alphabet.charAt(index);
+      sb.append(randomChar);
+    }
+
+    String longAttrValue = sb.toString();
+
+    IngestWarnings testIngestWarnings = spy(new IngestWarnings());
+    Map<String, Object> testAttributes = new HashMap<>();
+    testAttributes.put(longAttrValue, longAttrValue);
+    testAttributes.put("name", "bob");
+    testAttributes.put("sunny", true);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+
+    verify(testIngestWarnings).attributeNameWarning(longAttrValue);
     verify(testIngestWarnings).attributeValueWarning(longAttrValue);
   }
 }

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/util/IngestWarningsTest.java
@@ -3,8 +3,10 @@ package com.newrelic.telemetry.util;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.events.Event;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.metrics.Count;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
@@ -13,75 +15,109 @@ class IngestWarningsTest {
   @Test
   void validNumberOfAttributesForEventTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
-    verify(testIngestWarnings, never()).eventWarningNumAttributes();
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
+    verify(testIngestWarnings, never()).warningNumAttributes("Event");
   }
 
   @Test
   void invalidNumberOfAttributesForEventTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
 
     for (int i = 0; i < 300; i++) {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
-    verify(testIngestWarnings).eventWarningNumAttributes();
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
+    verify(testIngestWarnings).warningNumAttributes("Event");
   }
 
   @Test
   void validNumberOfAttributesForMetricTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Metric");
-    verify(testIngestWarnings, never()).metricWarningNumAttributes();
+    long testVal = 7;
+    long testStartTimeMs = 100;
+    long testEndTimeMs = 200;
+
+    Count testCount =
+        new Count("TestCount", testVal, testStartTimeMs, testEndTimeMs, testAttributes);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testCount);
+    verify(testIngestWarnings, never()).warningNumAttributes("Metric");
   }
 
   @Test
   void invalidNumberOfAttributesForMetricTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
     for (int i = 0; i < 110; i++) {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Metric");
-    verify(testIngestWarnings).metricWarningNumAttributes();
+    long testVal = 7;
+    long testStartTimeMs = 100;
+    long testEndTimeMs = 200;
+
+    Count testCount =
+        new Count("TestCount", testVal, testStartTimeMs, testEndTimeMs, testAttributes);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testCount);
+    verify(testIngestWarnings).warningNumAttributes("Metric");
   }
 
   @Test
   void validNumberOfAttributesForLogTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Log");
-    verify(testIngestWarnings, never()).logWarningNumAttributes();
+    Log testLog =
+        Log.builder()
+            .attributes(testAttributes)
+            .message("Processing Information")
+            .level("DEBUG")
+            .build();
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testLog);
+    verify(testIngestWarnings, never()).warningNumAttributes("Log");
   }
 
   @Test
   void invalidNumberOfAttributesForLogTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+    Attributes testAttributes = new Attributes();
 
     for (int i = 0; i < 300; i++) {
       testAttributes.put("Attribute" + i, i);
     }
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Log");
-    verify(testIngestWarnings).logWarningNumAttributes();
+    Log testLog =
+        Log.builder()
+            .attributes(testAttributes)
+            .message("Processing Information")
+            .level("DEBUG")
+            .build();
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testLog);
+    verify(testIngestWarnings).warningNumAttributes("Log");
   }
 
   // add # of attributes test(s) for logs
@@ -89,12 +125,16 @@ class IngestWarningsTest {
   @Test
   void validAttributeNamesTest() {
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
     verify(testIngestWarnings, never()).attributeNameWarning("test");
   }
 
@@ -115,25 +155,32 @@ class IngestWarningsTest {
     String longAttrName = sb.toString();
 
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+
+    Attributes testAttributes = new Attributes();
     testAttributes.put(longAttrName, 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
     verify(testIngestWarnings).attributeNameWarning(longAttrName);
   }
 
   @Test
   void validAttributeValuesTest() {
-
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", 1);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
     verify(testIngestWarnings, never()).attributeValueWarning("test");
   }
 
@@ -153,12 +200,17 @@ class IngestWarningsTest {
     String longAttrValue = sb.toString();
 
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+
+    Attributes testAttributes = new Attributes();
     testAttributes.put("test", longAttrValue);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
+
     verify(testIngestWarnings).attributeValueWarning(longAttrValue);
   }
 
@@ -178,12 +230,16 @@ class IngestWarningsTest {
     String longAttrValue = sb.toString();
 
     IngestWarnings testIngestWarnings = spy(new IngestWarnings());
-    Map<String, Object> testAttributes = new HashMap<>();
+
+    Attributes testAttributes = new Attributes();
     testAttributes.put(longAttrValue, longAttrValue);
     testAttributes.put("name", "bob");
     testAttributes.put("sunny", true);
 
-    testIngestWarnings.raiseIngestWarnings(testAttributes, "Event");
+    long timestamp = 300;
+    Event testEvent = new Event("SampleEvent", testAttributes, timestamp);
+
+    testIngestWarnings.raiseIngestWarnings(testAttributes.asMap(), testEvent);
 
     verify(testIngestWarnings).attributeNameWarning(longAttrValue);
     verify(testIngestWarnings).attributeValueWarning(longAttrValue);


### PR DESCRIPTION
This PR logs warnings if a user sends data that exceeds the New Relic Ingest API limits. For reference, here are the New Relic Ingest API limits for [Events](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-apis/introduction-event-api/#limits), [Metrics](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-apis/metric-api/metric-api-limits-restricted-attributes/), and [Logs](https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/#limits). In this PR, we are checking if data exceeds the following limits:

- Maximum number of attributes per Event / Metric / Log 
- Maximum attribute name length 
- Maximum attribute value length 

The IngestWarnings class contains all of the logic that checks if data exceeds Ingest API limits. The corresponding test file, IngestWarningsTest, contains unit tests to verify the functionality of IngestWarnings. 

A user can create an instance of the IngestWarnings class in the SDK. After creating this instance, a user can call the raiseIngestWarnings method to log warnings for a given piece of data. The raiseIngestWarnings method requires 2 arguments. The first argument is the Attributes object associated with the data. The second argument is the data type (Metric, Event, or Log). 

Below is a code snippet from the EventBuffer class that shows how IngestWarnings is used to log warnings in the SDK. 

```
private final IngestWarnings ingestWarnings = new IngestWarnings();

public void addEvent(Event event) {
    Map<String, Object> attributes = event.getAttributes().asMap();
    ingestWarnings.raiseIngestWarnings(attributes, "Event");
    events.add(event);
}
```





 
 


