### PR TITLE
Fix generics bug in MetricBuffer. Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1]
+- Fix bug introduced in `0.13.0` that broke the use of generics in the `MetricBuffer`.
+
 ## [0.13.0] 
 - EU Endpoint Support added by [updating the SenderConfigurationBuilder API](https://github.com/newrelic/newrelic-telemetry-sdk-java/pull/276). 
 - Includes endpoints that send Metric, Event, Log, and Span data to New Relic One.

--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ Maven dependencies:
     <dependency>
       <groupId>com.newrelic.telemetry</groupId>
       <artifactId>telemetry-core</artifactId>
-      <version>0.13.0</version>
+      <version>0.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.newrelic.telemetry</groupId>
       <artifactId>telemetry-http-okhttp</artifactId>
-      <version>0.13.0</version>
+      <version>0.13.1</version>
     </dependency>
 ```
 
 Gradle dependencies: 
 
 ```
-implementation("com.newrelic.telemetry:telemetry-core:0.13.0")
-implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.0")
+implementation("com.newrelic.telemetry:telemetry-core:0.13.1")
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.1")
 ```
 
 Take a look at the example code in the [telemetry_examples](telemetry_examples) module. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 
 # Here is where we manage the version
 group=com.newrelic.telemetry
-version=0.14.0
+version=0.13.1
 
 # Set this to true to enable using a local sonatype (for debugging publishing issues)
 # Start a local sonatype in docker with this command:

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/metrics/MetricBuffer.java
@@ -9,7 +9,6 @@ import com.newrelic.telemetry.util.IngestWarnings;
 import com.newrelic.telemetry.util.Utils;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.LoggerFactory;
@@ -40,36 +39,28 @@ public final class MetricBuffer {
   }
 
   /**
-   * Append a {@link Count} to this buffer, to be sent in the next {@link MetricBatch}.
+   * Append a {@link Metric} to this buffer, to be sent in the next {@link MetricBatch}.
    *
-   * @param countMetric The new {@link Count} instance to be sent.
+   * @param metric The new {@link Metric} instance to be sent.
    */
-  public void addMetric(Count countMetric) {
-    Map<String, Object> attributes = countMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, countMetric);
-    metrics.add(countMetric);
+  public void addMetric(Metric metric) {
+    raiseIngestWarnings(metric);
+    metrics.add(metric);
   }
 
   /**
-   * Append a {@link Gauge} to this buffer, to be sent in the next {@link MetricBatch}.
+   * Add IngestWarnings for concrete Metric implementations.
    *
-   * @param gaugeMetric The new {@link Gauge} instance to be sent.
+   * @param metric Metric instance to validate
    */
-  public void addMetric(Gauge gaugeMetric) {
-    Map<String, Object> attributes = gaugeMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, gaugeMetric);
-    metrics.add(gaugeMetric);
-  }
-
-  /**
-   * Append a {@link Summary} to this buffer, to be sent in the next {@link MetricBatch}.
-   *
-   * @param summaryMetric The new {@link Summary} instance to be sent.
-   */
-  public void addMetric(Summary summaryMetric) {
-    Map<String, Object> attributes = summaryMetric.getAttributes();
-    ingestWarnings.raiseIngestWarnings(attributes, summaryMetric);
-    metrics.add(summaryMetric);
+  private void raiseIngestWarnings(Metric metric) {
+    if (metric instanceof Count) {
+      ingestWarnings.raiseIngestWarnings(((Count) metric).getAttributes(), metric);
+    } else if (metric instanceof Gauge) {
+      ingestWarnings.raiseIngestWarnings(((Gauge) metric).getAttributes(), metric);
+    } else if (metric instanceof Summary) {
+      ingestWarnings.raiseIngestWarnings(((Summary) metric).getAttributes(), metric);
+    }
   }
 
   /**


### PR DESCRIPTION
`MetricBuffer.addMetric` was refactored in 0.13.0 to take concrete implementations of `Metric` as a parameter which broke the generic use of the method. This PR fixes that.