### PR TITLE
Freshen integration tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,4 +29,4 @@ jsonassertVersion=1.5.0
 mockitoVersion=2.23.0
 mockserverVersion=5.13.2
 okhttpVersion=4.8.0
-testContainerVersion=1.15.1
+testContainerVersion=1.17.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,6 @@ guavaVersion=27.1-jre
 junitVersion=5.3.1
 jsonassertVersion=1.5.0
 mockitoVersion=2.23.0
-mockserverVersion=5.5.1
+mockserverVersion=5.13.2
 okhttpVersion=4.8.0
 testContainerVersion=1.15.1

--- a/integration_test/src/test/java/com/newrelic/telemetry/EventApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/EventApiIntegrationTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockserver.model.JsonBody.json;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.MediaType;
 import com.newrelic.telemetry.events.Event;
 import com.newrelic.telemetry.events.EventBatchSender;
 import com.newrelic.telemetry.events.EventBuffer;
@@ -41,6 +40,7 @@ import org.mockserver.model.Delay;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.JsonBody;
+import org.mockserver.model.MediaType;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
@@ -55,7 +55,7 @@ class EventApiIntegrationTest {
   private static URL containerUrl;
 
   private static final GenericContainer<?> container =
-      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
+      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.13.2")
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
           .withExposedPorts(SERVICE_PORT);
 

--- a/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/LogApiIntegrationTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.JsonBody.json;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.MediaType;
 import com.newrelic.telemetry.logs.Log;
 import com.newrelic.telemetry.logs.LogBatch;
 import com.newrelic.telemetry.logs.LogBatchSender;
@@ -30,6 +29,7 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
@@ -42,7 +42,7 @@ class LogApiIntegrationTest {
   private static String containerIpAddress;
   private static MockServerClient mockServerClient;
   private static final GenericContainer<?> container =
-      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
+      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.13.2")
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
           .withExposedPorts(SERVICE_PORT);
   private static URL endpointUrl;

--- a/integration_test/src/test/java/com/newrelic/telemetry/MetricApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/MetricApiIntegrationTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockserver.model.JsonBody.json;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.MediaType;
 import com.newrelic.telemetry.exceptions.DiscardBatchException;
 import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
@@ -44,6 +43,7 @@ import org.mockserver.matchers.MatchType;
 import org.mockserver.model.Delay;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
@@ -58,7 +58,7 @@ class MetricApiIntegrationTest {
   private static URL endpointUrl;
 
   private static final GenericContainer<?> container =
-      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
+      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.13.2")
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
           .withExposedPorts(SERVICE_PORT);
 

--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.JsonBody.json;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.MediaType;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
@@ -30,6 +29,7 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
@@ -42,7 +42,7 @@ class SpanApiIntegrationTest {
   private static String containerIpAddress;
   private static MockServerClient mockServerClient;
   private static final GenericContainer<?> container =
-      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.5.1")
+      new GenericContainer<>("jamesdbloom/mockserver:mockserver-5.13.2")
           .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()))
           .withExposedPorts(SERVICE_PORT);
   private static URL endpointUrl;

--- a/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
+++ b/integration_test/src/test/java/com/newrelic/telemetry/SpanApiIntegrationTest.java
@@ -91,7 +91,7 @@ class SpanApiIntegrationTest {
                         "attributes",
                         ImmutableMap.of(
                             "duration.ms",
-                            60,
+                            60.0,
                             "service.name",
                             "Span Test Service",
                             "name",


### PR DESCRIPTION
Hi!  I ran into a few failures attempting to run the integration tests on an Apple M1 - e.g.  `org.mockserver.client.SocketConnectionException: Channel handler removed before valid response has been received` - that resolved as soon as I updated the org.mock-server and org.testcontainers dependencies.

As part of updating org.mock-server, I had to update the MediaType passed for the MockServerClient to `org.mockserver.model.MediaType` instead of `com.google.common.net.MediaType`.

Finally, the SpanApiIntegrationTest was failing due to the request body including a decimal point for `duration.ms`.  I'm assuming this is safe and not related to the other updates, but can't say for sure because I couldn't run the tests prior to the updates.