### PR TITLE
Update to okhttp 4.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The various builders for the Telemetry SDK components include an option to `useL
 ### For developers: 
 #### Requirements
 
-* Java 8 or greater
+* Java 11 or greater
 * For IDEA:
 * Docker & docker-compose must be installed for integration testing
 
@@ -93,7 +93,7 @@ For general querying information, see:
 CI builds are run on Github Actions: 
 ![build badge](https://github.com/newrelic/newrelic-telemetry-sdk-java/workflows/main%20build/badge.svg)
 
-The project uses gradle 6 for building, and the gradle wrapper is provided.
+The project uses Java 11 and gradle 6 for building, and the gradle wrapper is provided.
 
 To compile, run the tests and build the jars:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,5 @@ junitVersion=5.3.1
 jsonassertVersion=1.5.0
 mockitoVersion=2.23.0
 mockserverVersion=5.13.2
-okhttpVersion=4.8.0
+okhttpVersion=4.10.0
 testContainerVersion=1.17.3


### PR DESCRIPTION
[okhttp 4.10.0](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.10.0) updates its dependency on `org.jetbrains.kotlin:kotlin-stdlib` to version `1.6.20` which should address this [CVE](https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/273).

Resolves https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/273