### PR TITLE
Update Utils.generateUUID() to generate UUIDs conforming to RFC 4122 V4

### DIFF
--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/Utils.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/Utils.java
@@ -40,18 +40,16 @@ public class Utils {
 
     // Conform to the behavior of UUID.randomUUID()
     // version 4, variant 2: https://www.ietf.org/rfc/rfc4122.txt
-    randomBytes[6]  &= 0x0f;  /* clear version        */
-    randomBytes[6]  |= 0x40;  /* set to version 4     */
-    randomBytes[8]  &= 0x3f;  /* clear variant        */
-    randomBytes[8]  |= 0x80;  /* set to IETF variant  */
+    randomBytes[6] &= 0x0f; /* clear version        */
+    randomBytes[6] |= 0x40; /* set to version 4     */
+    randomBytes[8] &= 0x3f; /* clear variant        */
+    randomBytes[8] |= 0x80; /* set to IETF variant  */
 
     // UUID(byte[]) is private, so replicate the logic here to pack bytes into longs
     long msb = 0;
     long lsb = 0;
-    for (int i=0; i<8; i++)
-      msb = (msb << 8) | (randomBytes[i] & 0xff);
-    for (int i=8; i<16; i++)
-      lsb = (lsb << 8) | (randomBytes[i] & 0xff);
+    for (int i = 0; i < 8; i++) msb = (msb << 8) | (randomBytes[i] & 0xff);
+    for (int i = 8; i < 16; i++) lsb = (lsb << 8) | (randomBytes[i] & 0xff);
 
     return new UUID(msb, lsb);
   }

--- a/telemetry-core/src/main/java/com/newrelic/telemetry/util/Utils.java
+++ b/telemetry-core/src/main/java/com/newrelic/telemetry/util/Utils.java
@@ -29,7 +29,30 @@ public class Utils {
     return verifyNonNull(input, "input cannot be null");
   }
 
+  /**
+   * Generate a random UUID using ThreadLocalRandom.
+   *
+   * @return a UUID conforming to V4 of RFC 4122
+   */
   public static UUID generateUUID() {
-    return new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+    byte[] randomBytes = new byte[16];
+    ThreadLocalRandom.current().nextBytes(randomBytes);
+
+    // Conform to the behavior of UUID.randomUUID()
+    // version 4, variant 2: https://www.ietf.org/rfc/rfc4122.txt
+    randomBytes[6]  &= 0x0f;  /* clear version        */
+    randomBytes[6]  |= 0x40;  /* set to version 4     */
+    randomBytes[8]  &= 0x3f;  /* clear variant        */
+    randomBytes[8]  |= 0x80;  /* set to IETF variant  */
+
+    // UUID(byte[]) is private, so replicate the logic here to pack bytes into longs
+    long msb = 0;
+    long lsb = 0;
+    for (int i=0; i<8; i++)
+      msb = (msb << 8) | (randomBytes[i] & 0xff);
+    for (int i=8; i<16; i++)
+      lsb = (lsb << 8) | (randomBytes[i] & 0xff);
+
+    return new UUID(msb, lsb);
   }
 }

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/util/UtilsTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/util/UtilsTest.java
@@ -1,0 +1,24 @@
+package com.newrelic.telemetry.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UtilsTest {
+    @Test
+    @DisplayName("Utils.generateUUID() generates V4 UUID")
+    void testGenerateUUID() throws Exception {
+        final UUID uuid = Utils.generateUUID();
+
+        assertEquals(4, uuid.version()); // version 4 as per RFC 4122
+        assertEquals(2, uuid.variant()); // variant 2 as per RFC 4122
+
+        // UUID.randomUUID() generates V4 UUIDs
+        final UUID referenceUUID = UUID.randomUUID();
+        assertEquals(referenceUUID.version(), uuid.version());
+        assertEquals(referenceUUID.variant(), uuid.variant());
+    }
+}

--- a/telemetry-core/src/test/java/com/newrelic/telemetry/util/UtilsTest.java
+++ b/telemetry-core/src/test/java/com/newrelic/telemetry/util/UtilsTest.java
@@ -1,24 +1,23 @@
 package com.newrelic.telemetry.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class UtilsTest {
-    @Test
-    @DisplayName("Utils.generateUUID() generates V4 UUID")
-    void testGenerateUUID() throws Exception {
-        final UUID uuid = Utils.generateUUID();
+  @Test
+  @DisplayName("Utils.generateUUID() generates V4 UUID")
+  void testGenerateUUID() throws Exception {
+    final UUID uuid = Utils.generateUUID();
 
-        assertEquals(4, uuid.version()); // version 4 as per RFC 4122
-        assertEquals(2, uuid.variant()); // variant 2 as per RFC 4122
+    assertEquals(4, uuid.version()); // version 4 as per RFC 4122
+    assertEquals(2, uuid.variant()); // variant 2 as per RFC 4122
 
-        // UUID.randomUUID() generates V4 UUIDs
-        final UUID referenceUUID = UUID.randomUUID();
-        assertEquals(referenceUUID.version(), uuid.version());
-        assertEquals(referenceUUID.variant(), uuid.variant());
-    }
+    // UUID.randomUUID() generates V4 UUIDs
+    final UUID referenceUUID = UUID.randomUUID();
+    assertEquals(referenceUUID.version(), uuid.version());
+    assertEquals(referenceUUID.variant(), uuid.variant());
+  }
 }


### PR DESCRIPTION
This PR addresses the issue @Steven-M-Brown raised in https://github.com/newrelic/newrelic-telemetry-sdk-java/pull/292#issuecomment-1228879917.   The code in #292 will generate UUIDs that don't conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt).


The logic in `Utils.generateUUID()` is verbose because I thought it best to adhere as closely to the logic in [UUID.randomUUID()](https://github.com/openjdk/jdk17u-dev/blob/b4cba15a0e06c9126a85ce300c0653b58b9af9b2/src/java.base/share/classes/java/util/UUID.java#L147-L157) and the [UUID(byte[])](https://github.com/openjdk/jdk17u-dev/blob/b4cba15a0e06c9126a85ce300c0653b58b9af9b2/src/java.base/share/classes/java/util/UUID.java#L110-L120) constructor signature as possible.